### PR TITLE
fix(msr_etl): avoid default basic-auth failure for UBR queries

### DIFF
--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -3,7 +3,7 @@ from django.apps import AppConfig
 MODULE_NAME = "msr_etl"
 
 DEFAULT_CONFIG = {
-    "auth_type": "basic",  # noauth, basic, bearer
+    "auth_type": "noauth",  # noauth, basic, bearer
     "auth_basic_username": "",  # basic auth username
     "auth_basic_password": "",  # basic auth password
     "auth_bearer_token": "",  # bearer token

--- a/msr_etl/tests/test_auth_provider_defaults.py
+++ b/msr_etl/tests/test_auth_provider_defaults.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from msr_etl.apps import MsrEtlConfig
+from msr_etl.auth_provider import get_auth_provider
+from msr_etl.auth_provider.base import AuthError
+from msr_etl.auth_provider.noAuthAuthProvider import NoAuthProvider
+from msr_etl.auth_provider.basicAuthProvider import BasicAuthProvider
+
+
+class AuthProviderDefaultsTestCase(TestCase):
+    def test_default_auth_type_is_noauth(self):
+        self.assertEqual(MsrEtlConfig.auth_type, "noauth")
+
+    def test_get_auth_provider_uses_noauth_by_default(self):
+        provider = get_auth_provider()
+        self.assertIsInstance(provider, NoAuthProvider)
+
+    def test_basic_auth_raises_when_credentials_missing(self):
+        provider = BasicAuthProvider()
+        with self.assertRaises(AuthError):
+            provider.get_auth_header()


### PR DESCRIPTION
## Summary
- change msr_etl default auth type from basic to noauth
- add regression tests for default auth provider behavior

## Problem
msrUbrIndividuals could fail with Basic auth credentials not provided when no basic credentials are configured.

## Fix
Default module auth now uses noauth, preventing unexpected BasicAuth errors unless basic auth is explicitly configured.

## Testing
- Added unit tests in msr_etl/tests/test_auth_provider_defaults.py
- Runtime test execution skipped in this environment per request