### PR TITLE
refactor: rename ETL_CLASS to MSR_ETL_CLASS

### DIFF
--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -11,7 +11,7 @@ from msr_etl.adapters import UBRIndividualAdapter, UBRLocationAdapter
 from msr_etl.utils import (
     get_class_by_name,
     get_timestamped_batch_identifier,
-    ETL_CLASS,
+    MSR_ETL_CLASS,
 )
 from msr_etl.apps import MsrEtlConfig
 from core.gql.gql_mutations.base_mutation import BaseMutation
@@ -51,7 +51,7 @@ class MsrEtlServiceMutation(BaseMutation):
                     'detail': _('There is no ETL service with provided name')
                 }]
 
-            etl_service_class = get_class_by_name(ETL_CLASS, name_of_service)
+            etl_service_class = get_class_by_name(MSR_ETL_CLASS, name_of_service)
             service_kwargs = cls._get_supported_service_kwargs(etl_service_class, data)
 
             # Instantiate and execute the ETL service

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -17,7 +17,7 @@ from msr_etl.sources import UBRIndividualSource, UBRLocationSource
 from msr_etl.utils import (
     get_class_by_name,
     get_classes_in_module,
-    ETL_CLASS
+    MSR_ETL_CLASS
 )
 
 
@@ -50,7 +50,7 @@ class Query(graphene.ObjectType):
         service_name = kwargs.get("name_of_service", None)
         if service_name:
             # check if provided service etl class exists in application
-            class_service = get_class_by_name(ETL_CLASS, service_name)
+            class_service = get_class_by_name(MSR_ETL_CLASS, service_name)
             if class_service:
                 list_sr.append(
                     MsrEtlServiceGQLType(
@@ -59,7 +59,7 @@ class Query(graphene.ObjectType):
                 )
         else:
             # get all etl classes within module
-            class_service_list = get_classes_in_module(ETL_CLASS)
+            class_service_list = get_classes_in_module(MSR_ETL_CLASS)
             for class_service in class_service_list:
                 list_sr.append(
                     MsrEtlServiceGQLType(

--- a/msr_etl/utils.py
+++ b/msr_etl/utils.py
@@ -7,8 +7,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from typing import Any, Optional
 
 
-ETL_CLASS = "msr_etl.services"
-ETL = "msr_etl.services.base"
+MSR_ETL_CLASS = "msr_etl.services"
 
 
 def get_class_by_name(module_name, class_name):


### PR DESCRIPTION
## Summary
- rename ETL_CLASS constant usage to MSR_ETL_CLASS
- update ETL service class resolution references in GraphQL mutation and schema

## Commits
- refactor: rename ETL_CLASS to MSR_ETL_CLASS in utils
- refactor: use MSR_ETL_CLASS in gql mutations
- refactor: use MSR_ETL_CLASS in schema

## Testing
- skipped