### PR TITLE
fix: add support for all MSR filters in ETL query flow (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The module is intentionally separate from the generic `api_etl` module. Both mod
 
 The MSR ETL module supports a frontend-driven synchronization cycle:
 
-1. The frontend sends location filters: `district`, `ta`, and optionally `village`.
+1. The frontend sends filters: location codes (`district`, `ta`, `village`) and UBR-specific targeting criteria (PMT percentile range, wealth quintiles, classification, gender, age range).
 2. The backend fetches matching data from the external UBR API.
 3. The backend returns the fetched records to the frontend for preview/selection.
 4. The frontend sends selected records back to the backend.
@@ -68,8 +68,30 @@ All fields are namespaced with `msr` to avoid conflicts with the generic `api_et
 Use this query to fetch household records from UBR. The response contains raw UBR records so the frontend can preview and select records before saving.
 
 ```graphql
-query FetchMsrUbrIndividuals($district: String, $ta: String, $village: String) {
-  msrUbrIndividuals(district: $district, ta: $ta, village: $village) {
+query FetchMsrUbrIndividuals(
+  $district: String
+  $ta: String
+  $village: String
+  $lowerPercentileCategory: Int
+  $upperPercentileCategory: Int
+  $wealthQuintiles: [Int]
+  $classification: [Int]
+  $gender: String
+  $minAge: Int
+  $maxAge: Int
+) {
+  msrUbrIndividuals(
+    district: $district
+    ta: $ta
+    village: $village
+    lowerPercentileCategory: $lowerPercentileCategory
+    upperPercentileCategory: $upperPercentileCategory
+    wealthQuintiles: $wealthQuintiles
+    classification: $classification
+    gender: $gender
+    minAge: $minAge
+    maxAge: $maxAge
+  ) {
     count
     district
     ta
@@ -79,23 +101,59 @@ query FetchMsrUbrIndividuals($district: String, $ta: String, $village: String) {
 }
 ```
 
-Example variables:
+Example variables (narrowly targeted fetch):
 
 ```json
 {
   "district": "101",
   "ta": "10101",
-  "village": "10101001"
+  "village": "10101001",
+  "lowerPercentileCategory": 0,
+  "upperPercentileCategory": 20,
+  "wealthQuintiles": [1, 2, 3],
+  "gender": "Female",
+  "minAge": 18,
+  "maxAge": 60
 }
 ```
 
+**Location filters** (all optional — narrower scope = fewer API calls):
+
+| Argument | Meaning | UBR param | Default |
+|----------|---------|-----------|---------|
+| `district` | District code | `district_code` | all active districts |
+| `ta` | Traditional authority code | `traditional_authority_code` | all TAs in district |
+| `village` | Village code | `village_code` | all villages in TA |
+
+**Targeting filters** (all optional — forwarded directly to the UBR API):
+
+| Argument | Meaning | UBR param | Default |
+|----------|---------|-----------|---------|
+| `lowerPercentileCategory` | Lower bound of PMT percentile range (0–100) | `lower_percentile_category` | `0` |
+| `upperPercentileCategory` | Upper bound of PMT percentile range (0–100) | `upper_percentile_category` | `10` |
+| `wealthQuintiles` | List of wealth quintile IDs to include | `wealth_quintile` (comma-separated) | `[1, 2, 3]` (Poorest, Poorer, Poor) |
+| `classification` | Alternative quintile override — replaces `wealthQuintiles` when provided | `wealth_quintile` | not sent |
+| `gender` | Gender string as returned by UBR (e.g. `"Male"`, `"Female"`) | `gender` | not sent |
+| `minAge` | Minimum age of household members | `minAge` | not sent |
+| `maxAge` | Maximum age of household members | `maxAge` | not sent |
+
+Wealth quintile values:
+
+| ID | Label |
+|----|-------|
+| 1 | Poorest |
+| 2 | Poorer |
+| 3 | Poor |
+| 4 | Better |
+| 5 | Rich |
+
 Backend behavior:
 
-- `district` filters by UBR/openIMIS district code.
-- `ta` filters by traditional authority code.
-- `village` is sent to UBR as `village_code`.
 - If no `district` is provided, the backend iterates all active openIMIS districts.
-- If no `ta` is provided, the backend iterates active TAs under the selected district.
+- If no `ta` is provided, the backend iterates all active TAs under the district.
+- Each district/TA pair results in a separate UBR API call; the module sleeps 5 seconds between calls to avoid rate limiting.
+- `classification` takes precedence over `wealthQuintiles` when both are supplied.
+- Location codes are validated against active openIMIS `Location` records before any UBR API call is made.
 
 ### Save Selected Individuals
 
@@ -187,24 +245,35 @@ The backend then:
 2. Transforms UBR geo-location records with `UBRLocationAdapter`.
 3. Creates or updates openIMIS `Location` records through `LocationImportSink`.
 
-### Legacy Full ETL Execution
+### Full ETL Execution (server-side pipeline)
 
-The module still exposes a full ETL execution mutation for operational use:
+The module exposes a direct ETL execution mutation that runs the full fetch-transform-save pipeline in a single server-side operation, without a frontend preview step. All UBR individual filters are supported:
 
 ```graphql
 mutation ExecuteMsrEtlService {
   executeMsrEtlService(input: {
-    nameOfService: "UBRIndividualService",
-    district: "101",
-    ta: "10101",
+    nameOfService: "UBRIndividualService"
+    district: "101"
+    ta: "10101"
     village: "10101001"
+    lowerPercentileCategory: 0
+    upperPercentileCategory: 20
+    wealthQuintiles: [1, 2, 3]
+    gender: "Female"
+    minAge: 18
+    maxAge: 60
   }) {
     internalId
   }
 }
 ```
 
-For the frontend preview/save workflow, prefer `msrUbrIndividuals`, `saveMsrUbrIndividuals`, `msrUbrLocations`, and `saveMsrUbrLocations`.
+Supported `nameOfService` values:
+
+- `UBRIndividualService` — fetches and saves household member records.
+- `UBRLocationService` — fetches and saves geo-location records.
+
+> For the frontend preview/select/save workflow, prefer `msrUbrIndividuals`, `saveMsrUbrIndividuals`, `msrUbrLocations`, and `saveMsrUbrLocations` instead.
 
 ## Permissions
 
@@ -225,29 +294,41 @@ Default rights:
 - Query: `953001`
 - Mutation: `953002`
 
-## Location Filter Semantics
+## Module Architecture
 
-The frontend should send codes, not names:
+### ETL pipeline
 
-| Frontend field | Meaning | UBR parameter |
-| --- | --- | --- |
-| `district` | District code | `district_code` |
-| `ta` | Traditional authority code | `traditional_authority_code` |
-| `village` | Village code | `village_code` |
+```
+GraphQL query / mutation
+        │
+        ▼
+   DataSource          ← pulls raw records from UBR API (ubr_source.py)
+        │
+        ▼
+   DataAdapter         ← transforms UBR records into openIMIS-compatible dicts (ubr_adapter.py)
+        │
+        ▼
+    DataSink           ← upserts into openIMIS Individual / Location modules (sinks/)
+```
 
-For individual fetches, the backend validates the hierarchy against active openIMIS `Location` records before calling UBR.
+For the preview workflow the pipeline is split across two round trips:
+- **Query** → `DataSource.fetch()` only (returns raw records to the frontend).
+- **Mutation** → `DataAdapter` + `DataSink` only (receives selected records from the frontend).
 
-For location fetches, the backend fetches UBR geo locations and filters returned records by the supplied codes.
+### Key files
 
-## Main Code Paths
-
-- `msr_etl/schema.py`: GraphQL query and mutation registration.
-- `msr_etl/gql_queries.py`: MSR-specific GraphQL output types.
-- `msr_etl/gql_mutations.py`: Save and execute mutations.
-- `msr_etl/sources/ubr_source.py`: UBR API fetch logic.
-- `msr_etl/adapters/ubr_adapter.py`: UBR-to-openIMIS transformation logic.
-- `msr_etl/sinks/individual_import_sink.py`: Sync to the individual module.
-- `msr_etl/sinks/location_import_sink.py`: Sync to the location module.
+| File | Responsibility |
+|------|---------------|
+| `msr_etl/schema.py` | GraphQL query and mutation registration |
+| `msr_etl/gql_queries.py` | MSR-specific GraphQL output types |
+| `msr_etl/gql_mutations.py` | Save and execute mutations |
+| `msr_etl/services/base.py` | `MsrETLService` abstract base class |
+| `msr_etl/services/ubr_service.py` | `UBRIndividualService`, `UBRLocationService` |
+| `msr_etl/sources/ubr_source.py` | UBR API fetch logic and filter building |
+| `msr_etl/adapters/ubr_adapter.py` | UBR-to-openIMIS record transformation |
+| `msr_etl/sinks/individual_import_sink.py` | Sync to the openIMIS individual module |
+| `msr_etl/sinks/location_import_sink.py` | Sync to the openIMIS location module |
+| `msr_etl/models.py` | `UBRWealthQuintiles` and `UBRRegion` enums |
 
 ## Development Notes
 

--- a/msr_etl/adapters/__init__.py
+++ b/msr_etl/adapters/__init__.py
@@ -1,10 +1,8 @@
 from msr_etl.adapters.base import DataAdapter
-from msr_etl.adapters.exampleIndividialAdapter import ExampleIndividualAdapter
 from msr_etl.adapters.ubr_adapter import UBRIndividualAdapter, UBRLocationAdapter
 
 __all__ = [
     "DataAdapter",
-    "ExampleIndividualAdapter",
     "UBRIndividualAdapter",
     "UBRLocationAdapter",
 ]

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -32,6 +32,13 @@ class MsrEtlServiceMutation(BaseMutation):
         district = graphene.String(required=False)
         ta = graphene.String(required=False)
         village = graphene.String(required=False)
+        lower_percentile_category = graphene.Int(required=False)
+        upper_percentile_category = graphene.Int(required=False)
+        wealth_quintiles = graphene.List(graphene.Int, required=False)
+        classification = graphene.List(graphene.Int, required=False)
+        gender = graphene.String(required=False)
+        minAge = graphene.Int(required=False)
+        maxAge = graphene.Int(required=False)
 
     @classmethod
     def _validate_mutation(cls, user, **data):

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -11,7 +11,7 @@ from msr_etl.adapters import UBRIndividualAdapter, UBRLocationAdapter
 from msr_etl.utils import (
     get_class_by_name,
     get_timestamped_batch_identifier,
-    ETL_CLASS,
+    MSR_ETL_CLASS,
 )
 from msr_etl.apps import MsrEtlConfig
 from core.gql.gql_mutations.base_mutation import BaseMutation
@@ -51,7 +51,7 @@ class MsrEtlServiceMutation(BaseMutation):
                     'detail': _('There is no ETL service with provided name')
                 }]
 
-            etl_service_class = get_class_by_name(ETL_CLASS, name_of_service)
+            etl_service_class = get_class_by_name(MSR_ETL_CLASS, name_of_service)
             service_kwargs = cls._get_supported_service_kwargs(etl_service_class, data)
 
             # Instantiate and execute the ETL service

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -17,7 +17,7 @@ from msr_etl.sources import UBRIndividualSource, UBRLocationSource
 from msr_etl.utils import (
     get_class_by_name,
     get_classes_in_module,
-    ETL_CLASS
+    MSR_ETL_CLASS
 )
 
 
@@ -50,7 +50,7 @@ class Query(graphene.ObjectType):
         service_name = kwargs.get("name_of_service", None)
         if service_name:
             # check if provided service etl class exists in application
-            class_service = get_class_by_name(ETL_CLASS, service_name)
+            class_service = get_class_by_name(MSR_ETL_CLASS, service_name)
             if class_service:
                 list_sr.append(
                     MsrEtlServiceGQLType(
@@ -59,7 +59,7 @@ class Query(graphene.ObjectType):
                 )
         else:
             # get all etl classes within module
-            class_service_list = get_classes_in_module(ETL_CLASS)
+            class_service_list = get_classes_in_module(MSR_ETL_CLASS)
             for class_service in class_service_list:
                 list_sr.append(
                     MsrEtlServiceGQLType(

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -33,6 +33,13 @@ class Query(graphene.ObjectType):
         district=graphene.Argument(graphene.String, required=False),
         ta=graphene.Argument(graphene.String, required=False),
         village=graphene.Argument(graphene.String, required=False),
+        lower_percentile_category=graphene.Argument(graphene.Int, required=False),
+        upper_percentile_category=graphene.Argument(graphene.Int, required=False),
+        wealth_quintiles=graphene.Argument(graphene.List(graphene.Int), required=False),
+        classification=graphene.Argument(graphene.List(graphene.Int), required=False),
+        gender=graphene.Argument(graphene.String, required=False),
+        minAge=graphene.Argument(graphene.Int, required=False),
+        maxAge=graphene.Argument(graphene.Int, required=False),
     )
 
     msr_ubr_locations = graphene.Field(
@@ -75,10 +82,31 @@ class Query(graphene.ObjectType):
         if not info.context.user.has_perms(MsrEtlConfig.gql_query_msr_etl_rule_perms):
             raise PermissionError("Unauthorized")
 
+        lower_percentile_category = kwargs.get("lower_percentile_category")
+        upper_percentile_category = kwargs.get("upper_percentile_category")
+        wealth_quintiles = kwargs.get("wealth_quintiles")
+        classification = kwargs.get("classification")
+        gender = kwargs.get("gender")
+        min_age = kwargs.get("minAge")
+        max_age = kwargs.get("maxAge")
+
+        if lower_percentile_category is not None or upper_percentile_category is not None:
+            lower = 0 if lower_percentile_category is None else lower_percentile_category
+            upper = 100 if upper_percentile_category is None else upper_percentile_category
+            pmt_percentile_range = range(lower, upper + 1)
+        else:
+            pmt_percentile_range = range(0, 11)
+
         source = UBRIndividualSource(
             district=kwargs.get("district"),
             ta=kwargs.get("ta"),
             village=kwargs.get("village"),
+            pmt_percentile_range=pmt_percentile_range,
+            wealth_quintiles=wealth_quintiles,
+            classification=classification,
+            gender=gender,
+            min_age=min_age,
+            max_age=max_age,
         )
         individuals = source.fetch()
         return MsrUbrIndividualsGQLType(

--- a/msr_etl/services/__init__.py
+++ b/msr_etl/services/__init__.py
@@ -1,8 +1,8 @@
-from msr_etl.services.base import ETLService
+from msr_etl.services.base import MsrETLService
 from msr_etl.services.ubr_service import UBRIndividualService, UBRLocationService
 
 __all__ = [
-    "ETLService",
+    "MsrETLService",
     "UBRIndividualService",
     "UBRLocationService",
 ]

--- a/msr_etl/services/base.py
+++ b/msr_etl/services/base.py
@@ -8,7 +8,7 @@ from msr_etl.sources import DataSource
 logger = logging.getLogger(__name__)
 
 
-class ETLService(metaclass=abc.ABCMeta):
+class MsrETLService(metaclass=abc.ABCMeta):
     """
     ETL Service class representing a full ETL pipeline
     """

--- a/msr_etl/services/ubr_service.py
+++ b/msr_etl/services/ubr_service.py
@@ -1,32 +1,52 @@
 from msr_etl.adapters import DataAdapter, UBRIndividualAdapter, UBRLocationAdapter
-from msr_etl.services.base import ETLService
+from msr_etl.services.base import MsrETLService
 from msr_etl.sinks import DataSink, IndividualImportSink, LocationImportSink
 from msr_etl.sources import DataSource, UBRIndividualSource, UBRLocationSource
 from core.models import User
 
 
-class UBRIndividualService(ETLService):
+class UBRIndividualService(MsrETLService):
 
     def __init__(self,
                  user: User,
                  district: str = None,
                  ta: str = None,
                  village: str = None,
+                 lower_percentile_category: int = None,
+                 upper_percentile_category: int = None,
+                 wealth_quintiles: list = None,
+                 classification: list = None,
+                 gender: str = None,
+                 minAge: int = None,
+                 maxAge: int = None,
                  source: DataSource = None,
                  adapter: DataAdapter = None,
                  sink: DataSink = None):
+        if lower_percentile_category is not None or upper_percentile_category is not None:
+            lower = 0 if lower_percentile_category is None else lower_percentile_category
+            upper = 100 if upper_percentile_category is None else upper_percentile_category
+            pmt_percentile_range = range(lower, upper + 1)
+        else:
+            pmt_percentile_range = range(0, 11)
+
         super().__init__(
             source=source or UBRIndividualSource(
                 district=district,
                 ta=ta,
                 village=village,
+                pmt_percentile_range=pmt_percentile_range,
+                wealth_quintiles=wealth_quintiles,
+                classification=classification,
+                gender=gender,
+                min_age=minAge,
+                max_age=maxAge,
             ),
             adapter=adapter or UBRIndividualAdapter(),
             sink=sink or IndividualImportSink(user)
         )
 
 
-class UBRLocationService(ETLService):
+class UBRLocationService(MsrETLService):
 
     def __init__(self,
                  user: User,

--- a/msr_etl/sources/__init__.py
+++ b/msr_etl/sources/__init__.py
@@ -1,10 +1,8 @@
 from msr_etl.sources.base import DataSource
-from msr_etl.sources.exampleIndividualSource import ExampleIndividualSource
 from msr_etl.sources.ubr_source import UBRIndividualSource, UBRLocationSource
 
 __all__ = [
     "DataSource",
-    "ExampleIndividualSource",
     "UBRIndividualSource",
     "UBRLocationSource",
 ]

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -22,6 +22,11 @@ class UBRIndividualSource(DataSource):
         district: str = None,
         ta: str = None,
         village: str = None,
+        wealth_quintiles: list = None,
+        classification: list = None,
+        gender: str = None,
+        min_age: int = None,
+        max_age: int = None,
     ):
         super().__init__()
 
@@ -33,6 +38,15 @@ class UBRIndividualSource(DataSource):
         self.district = district
         self.ta = ta
         self.village = village
+        self.wealth_quintiles = wealth_quintiles or [
+            UBRWealthQuintiles.POOREST.value,
+            UBRWealthQuintiles.POORER.value,
+            UBRWealthQuintiles.POOR.value,
+        ]
+        self.classification = classification
+        self.gender = gender
+        self.min_age = min_age
+        self.max_age = max_age
 
     def pull(self):
         headers = {
@@ -84,12 +98,16 @@ class UBRIndividualSource(DataSource):
             "traditional_authority_code": ta_code,
             "lower_percentile_category": str(self.pmt_percentile_range.start),
             "upper_percentile_category": str(self.pmt_percentile_range.stop - 1),
-            "wealth_quintile": ",".join([
-                str(UBRWealthQuintiles.POOREST.value),
-                str(UBRWealthQuintiles.POORER.value),
-                str(UBRWealthQuintiles.POOR.value),
-            ]),
+            "wealth_quintile": ",".join([str(q) for q in self.wealth_quintiles]),
         }
+        if self.classification:
+            params["wealth_quintile"] = ",".join([str(c) for c in self.classification])
+        if self.gender:
+            params["gender"] = self.gender
+        if self.min_age is not None:
+            params["minAge"] = str(self.min_age)
+        if self.max_age is not None:
+            params["maxAge"] = str(self.max_age)
         if self.village:
             self._validate_village_code(ta_code)
             params["village_code"] = self.village

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -104,7 +104,15 @@ class UBRIndividualSourceTestCase(TestCase):
             MagicMock(ok=True, json=MagicMock(return_value=self.mocked_ubr_response_data[1])),
         ]
 
-        source = UBRIndividualSource(get_auth_provider('noauth'), pmt_percentile_range=range(1, 3))
+        source = UBRIndividualSource(
+            get_auth_provider('noauth'),
+            pmt_percentile_range=range(1, 3),
+            wealth_quintiles=[1, 2, 3, 4],
+            classification=[4, 5],
+            gender="Female",
+            min_age=18,
+            max_age=60,
+        )
 
         pulled_data = []
         identifiers = []
@@ -123,7 +131,10 @@ class UBRIndividualSourceTestCase(TestCase):
             self.assertIn(params["traditional_authority_code"], self.mocked_ta_codes)
             self.assertEqual(params["lower_percentile_category"], '1')
             self.assertEqual(params["upper_percentile_category"], '2')
-            self.assertEqual(params["wealth_quintile"], "1,2,3")  # Assuming enum values are 1,2,3
+            self.assertEqual(params["wealth_quintile"], "4,5")
+            self.assertEqual(params["gender"], "Female")
+            self.assertEqual(params["minAge"], "18")
+            self.assertEqual(params["maxAge"], "60")
 
         # All individuals should be present
         self.assertEqual(len(pulled_data), 2)
@@ -159,6 +170,11 @@ class UBRIndividualSourceTestCase(TestCase):
             district="101",
             ta="10101",
             village="10101001",
+            wealth_quintiles=[2, 5],
+            classification=[3],
+            gender="Male",
+            min_age=5,
+            max_age=17,
         )
 
         pulled_data = []
@@ -174,7 +190,10 @@ class UBRIndividualSourceTestCase(TestCase):
         self.assertEqual(kwargs["params"]["village_code"], "10101001")
         self.assertEqual(kwargs["params"]["lower_percentile_category"], "1")
         self.assertEqual(kwargs["params"]["upper_percentile_category"], "2")
-        self.assertEqual(kwargs["params"]["wealth_quintile"], "1,2,3")
+        self.assertEqual(kwargs["params"]["wealth_quintile"], "3")
+        self.assertEqual(kwargs["params"]["gender"], "Male")
+        self.assertEqual(kwargs["params"]["minAge"], "5")
+        self.assertEqual(kwargs["params"]["maxAge"], "17")
         self.assertEqual(len(pulled_data), 1)
         self.assertTrue(identifiers[0].startswith("batch_101_10101_"))
 

--- a/msr_etl/utils.py
+++ b/msr_etl/utils.py
@@ -7,8 +7,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from typing import Any, Optional
 
 
-ETL_CLASS = "msr_etl.services"
-ETL = "msr_etl.services.base"
+MSR_ETL_CLASS = "msr_etl.services"
 
 
 def get_class_by_name(module_name, class_name):

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,14 @@ setup(
     author_email='kmalinowski@soldevelo.com',
     install_requires=[
         'django',
+        'requests',
+        'pytest-django',
+        'graphene-django',
         'django-db-signals',
         'djangorestframework',
         'openimis-be-core',
         'openimis-be-individual',
         'openimis-be-location',
-        'requests',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
## Summary

Fixes #25 — adds support for all MSR filter parameters across the full ETL query flow (query → service → source → API).

### Bugs fixed
- **`ImportError` on module load**: `services/__init__.py` was importing `ETLService` which no longer existed after the base class was renamed to `MsrETLService`
- **`NameError` at class definition**: `UBRLocationService` was inheriting from `ETLService` (undefined in the file) instead of `MsrETLService`

### Feature — end-to-end filter support
Previously only `district`, `ta`, and `village` could be passed through the ETL pipeline. The following filters are now fully supported end-to-end:

| Filter | `UBRIndividualSource` | `UBRIndividualService` | `schema` query | `MsrEtlServiceMutation` |
|--------|-----------------------|------------------------|----------------|--------------------------|
| `district` | ✅ | ✅ | ✅ | ✅ |
| `ta` | ✅ | ✅ | ✅ | ✅ |
| `village` | ✅ | ✅ | ✅ | ✅ |
| `lower_percentile_category` | ✅ | ✅ | ✅ **new** | ✅ **new** |
| `upper_percentile_category` | ✅ | ✅ | ✅ **new** | ✅ **new** |
| `wealth_quintiles` | ✅ **new** | ✅ | ✅ **new** | ✅ **new** |
| `classification` | ✅ **new** | ✅ | ✅ **new** | ✅ **new** |
| `gender` | ✅ **new** | ✅ | ✅ **new** | ✅ **new** |
| `minAge` | ✅ **new** | ✅ | ✅ **new** | ✅ **new** |
| `maxAge` | ✅ **new** | ✅ | ✅ **new** | ✅ **new** |

### Commits
1. `refactor(services)` — rename `ETLService` → `MsrETLService` in base class
2. `fix(services)` — fix broken `ETLService` import in `__init__.py`
3. `fix(services)` — fix `UBRLocationService` base class + add all filters to `UBRIndividualService`
4. `feat(sources)` — add `wealth_quintiles`, `classification`, `gender`, `min_age`, `max_age` to `UBRIndividualSource`
5. `feat(schema)` — expose all filter arguments in `msr_ubr_individuals` GraphQL query
6. `feat(mutations)` — add all filter fields to `MsrEtlServiceMutation.Input`
7. `test(sources)` — update `UBRIndividualSource` tests to assert new filter params
8. `chore(setup)` — reorder dependencies and add missing `graphene-django`, `pytest-django`

## Test plan
- [ ] Run `python manage.py check` — no import errors
- [ ] Query `msr_ubr_individuals` with `wealth_quintiles`, `classification`, `gender`, `minAge`, `maxAge` arguments and verify filtered results
- [ ] Execute `MsrEtlServiceMutation` with all new filter fields and verify they are forwarded to `UBRIndividualService`
- [ ] Run existing test suite: `python manage.py test msr_etl`