### PR TITLE
Add UBR household eligibility filters

### DIFF
--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -13,6 +13,8 @@ DEFAULT_CONFIG = {
     "source_headers": {},
     "source_batch_size": 50,
 
+    "ubr_programme_parameter_id": 2,
+
     "adapter_first_name_field": "firstName",
     "adapter_last_name_field": "lastName",
     "adapter_dob_field": "dateOfBirth",
@@ -40,6 +42,8 @@ class MsrEtlConfig(AppConfig):
     source_url = None
     source_headers = None
     source_batch_size = None
+
+    ubr_programme_parameter_id = None
 
     adapter_first_name_field = None
     adapter_last_name_field = None

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -39,6 +39,10 @@ class MsrEtlServiceMutation(BaseMutation):
         gender = graphene.String(required=False)
         minAge = graphene.Int(required=False)
         maxAge = graphene.Int(required=False)
+        has_labour = graphene.Boolean(required=False)
+        labour_constrained = graphene.Boolean(required=False)
+        excluded_programme_codes = graphene.List(graphene.String, required=False)
+        household_head_gender = graphene.Int(required=False)
 
     @classmethod
     def _validate_mutation(cls, user, **data):

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -40,6 +40,10 @@ class Query(graphene.ObjectType):
         gender=graphene.Argument(graphene.String, required=False),
         minAge=graphene.Argument(graphene.Int, required=False),
         maxAge=graphene.Argument(graphene.Int, required=False),
+        has_labour=graphene.Argument(graphene.Boolean, required=False),
+        labour_constrained=graphene.Argument(graphene.Boolean, required=False),
+        excluded_programme_codes=graphene.Argument(graphene.List(graphene.String), required=False),
+        household_head_gender=graphene.Argument(graphene.Int, required=False),
     )
 
     msr_ubr_locations = graphene.Field(
@@ -89,6 +93,10 @@ class Query(graphene.ObjectType):
         gender = kwargs.get("gender")
         min_age = kwargs.get("minAge")
         max_age = kwargs.get("maxAge")
+        has_labour = kwargs.get("has_labour")
+        labour_constrained = kwargs.get("labour_constrained")
+        excluded_programme_codes = kwargs.get("excluded_programme_codes")
+        household_head_gender = kwargs.get("household_head_gender")
 
         if lower_percentile_category is not None or upper_percentile_category is not None:
             lower = 0 if lower_percentile_category is None else lower_percentile_category
@@ -107,6 +115,10 @@ class Query(graphene.ObjectType):
             gender=gender,
             min_age=min_age,
             max_age=max_age,
+            has_labour=has_labour,
+            labour_constrained=labour_constrained,
+            excluded_programme_codes=excluded_programme_codes,
+            household_head_gender=household_head_gender,
         )
         individuals = source.fetch()
         return MsrUbrIndividualsGQLType(

--- a/msr_etl/services/ubr_service.py
+++ b/msr_etl/services/ubr_service.py
@@ -19,6 +19,10 @@ class UBRIndividualService(MsrETLService):
                  gender: str = None,
                  minAge: int = None,
                  maxAge: int = None,
+                 has_labour: bool = None,
+                 labour_constrained: bool = None,
+                 excluded_programme_codes: list = None,
+                 household_head_gender: int = None,
                  source: DataSource = None,
                  adapter: DataAdapter = None,
                  sink: DataSink = None):
@@ -40,6 +44,10 @@ class UBRIndividualService(MsrETLService):
                 gender=gender,
                 min_age=minAge,
                 max_age=maxAge,
+                has_labour=has_labour,
+                labour_constrained=labour_constrained,
+                excluded_programme_codes=excluded_programme_codes,
+                household_head_gender=household_head_gender,
             ),
             adapter=adapter or UBRIndividualAdapter(),
             sink=sink or IndividualImportSink(user)

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -27,6 +27,10 @@ class UBRIndividualSource(DataSource):
         gender: str = None,
         min_age: int = None,
         max_age: int = None,
+        has_labour: bool = None,
+        labour_constrained: bool = None,
+        excluded_programme_codes: list = None,
+        household_head_gender: int = None,
     ):
         super().__init__()
 
@@ -47,6 +51,12 @@ class UBRIndividualSource(DataSource):
         self.gender = gender
         self.min_age = min_age
         self.max_age = max_age
+        self.has_labour = has_labour
+        self.labour_constrained = labour_constrained
+        self.excluded_programme_codes = [
+            str(code) for code in (excluded_programme_codes or [])
+        ]
+        self.household_head_gender = household_head_gender
 
     def pull(self):
         headers = {
@@ -129,7 +139,8 @@ class UBRIndividualSource(DataSource):
             logger.error(f"Error in response: {body.get('error_message')}")
             raise self.Error(f"Error in response: {body.get('error_message')}")
 
-        return body.get("targeting_data", [])
+        rows = body.get("targeting_data", [])
+        return self._apply_local_filters(rows)
 
     def _get_district_codes(self):
         if self.district:
@@ -175,6 +186,123 @@ class UBRIndividualSource(DataSource):
             raise self.Error(
                 f"Village code '{self.village}' was not found under TA '{ta_code}'."
             )
+
+    def _apply_local_filters(self, rows):
+        filtered = []
+
+        for row in rows:
+            if self.has_labour is not None:
+                if self._household_has_labour(row) != self.has_labour:
+                    continue
+
+            if self.labour_constrained is not None:
+                if self._household_is_labour_constrained(row) != self.labour_constrained:
+                    continue
+
+            if self.household_head_gender is not None:
+                if not self._household_head_gender_matches(row):
+                    continue
+
+            if self.excluded_programme_codes:
+                if self._household_has_excluded_programme(row):
+                    continue
+
+            filtered.append(row)
+
+        return filtered
+
+
+    def _household_has_labour(self, row):
+        summary = row.get("household_summary") or {}
+        members_fit_for_work = summary.get("members_fit_for_work")
+
+        try:
+            return int(members_fit_for_work or 0) > 0
+        except (TypeError, ValueError):
+            members = row.get("household_members") or []
+            return any(self._as_bool(member.get("fit_for_work")) for member in members)
+
+
+    def _household_is_labour_constrained(self, row):
+        summary = row.get("household_summary") or {}
+        return self._as_bool(summary.get("labour_constrained"))
+
+
+    def _household_head_gender_matches(self, row):
+        summary = row.get("household_summary") or {}
+        household_head_gender = summary.get("household_head_gender")
+
+        if household_head_gender is None:
+            return False
+
+        return str(household_head_gender) == str(self.household_head_gender)
+
+
+    def _household_has_excluded_programme(self, row):
+        programme_parameter_id = str(
+            getattr(MsrEtlConfig, "ubr_programme_parameter_id", 2) or 2
+        )
+        excluded_codes = set(self.excluded_programme_codes)
+
+        for response in self._as_list(row.get("household_combined_responses")):
+            general_parameter = response.get("general_parameter") or {}
+            if self._general_parameter_matches_programme(
+                general_parameter,
+                programme_parameter_id,
+                excluded_codes,
+            ):
+                return True
+
+        for programme in self._as_list(row.get("household_programmes")):
+            general_parameter = programme.get("general_parameter") or programme
+            if self._general_parameter_matches_programme(
+                general_parameter,
+                programme_parameter_id,
+                excluded_codes,
+            ):
+                return True
+
+        return False
+
+
+    @staticmethod
+    def _general_parameter_matches_programme(
+        general_parameter,
+        programme_parameter_id,
+        excluded_codes,
+    ):
+        if not general_parameter:
+            return False
+
+        return (
+            str(general_parameter.get("parameter_id")) == programme_parameter_id
+            and str(general_parameter.get("parameter_code")) in excluded_codes
+        )
+
+
+    @staticmethod
+    def _as_bool(value):
+        if isinstance(value, bool):
+            return value
+
+        if value is None:
+            return False
+
+        if isinstance(value, (int, float)):
+            return value == 1
+
+        return str(value).strip().lower() in ("1", "true", "yes", "y")
+
+
+    @staticmethod
+    def _as_list(value):
+        if value is None:
+            return []
+
+        if isinstance(value, list):
+            return value
+
+        return [value]
 
 
 class UBRLocationSource(DataSource):


### PR DESCRIPTION
Adds UBR household eligibility filters to the MSR ETL pull flow.

Changes:
- Adds labour availability filtering.
- Adds labour-constrained household filtering.
- Adds programme exclusion filtering using UBR general_parameter parameter_id/parameter_code.
- Adds household head gender filtering.
- Applies local filters after UBR targeting data is fetched.
- Exposes the filters through GraphQL query and generic ETL mutation/service flow.

Validation:
- python -m compileall msr_etl
- git diff --check

Target branch: sprint/2026-07