### PR TITLE
Add automatic UBR individuals import mutation

### DIFF
--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = {
 
     "sink_model_lookup_field": "json_ext__external_id",
     "sink_update_existing": True,
+    "sink_import_username": "",
 
     "gql_query_msr_etl_rule_perms": ["953001"],
     "gql_mutation_execute_msr_etl_rule_perms": ["953002"],
@@ -53,6 +54,7 @@ class MsrEtlConfig(AppConfig):
 
     sink_model_lookup_field = None
     sink_update_existing = None
+    sink_import_username = None
 
     gql_query_msr_etl_rule_perms = None
     gql_mutation_execute_msr_etl_rule_perms = None

--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -13,6 +13,8 @@ DEFAULT_CONFIG = {
     "source_headers": {},
     "source_batch_size": 50,
 
+    "ubr_programme_parameter_id": 2,
+
     "adapter_first_name_field": "firstName",
     "adapter_last_name_field": "lastName",
     "adapter_dob_field": "dateOfBirth",
@@ -40,6 +42,8 @@ class MsrEtlConfig(AppConfig):
     source_url = None
     source_headers = None
     source_batch_size = None
+
+    ubr_programme_parameter_id = None
 
     adapter_first_name_field = None
     adapter_last_name_field = None

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -17,6 +17,7 @@ from msr_etl.apps import MsrEtlConfig
 from core.gql.gql_mutations.base_mutation import BaseMutation
 from core.schema import OpenIMISMutation
 from msr_etl.sinks import IndividualImportSink, LocationImportSink
+from msr_etl.services import UBRIndividualService
 from msr_etl.sources import UBRLocationSource
 
 
@@ -91,6 +92,64 @@ class MsrEtlServiceMutation(BaseMutation):
             for key, value in data.items()
             if value is not None and key in supported_params
         }
+
+
+class ExecuteMsrUbrIndividualsImportMutation(BaseMutation):
+    """
+    Mutation to fetch filtered UBR household records and submit them directly
+    into the openIMIS Individual import workflow.
+    """
+    _mutation_class = "ExecuteMsrUbrIndividualsImportMutation"
+    _mutation_module = "msr_etl"
+
+    class Input(OpenIMISMutation.Input):
+        district = graphene.String(required=False)
+        ta = graphene.String(required=False)
+        village = graphene.String(required=False)
+        lower_percentile_category = graphene.Int(required=False)
+        upper_percentile_category = graphene.Int(required=False)
+        wealth_quintiles = graphene.List(graphene.Int, required=False)
+        classification = graphene.List(graphene.Int, required=False)
+        gender = graphene.String(required=False)
+        minAge = graphene.Int(required=False)
+        maxAge = graphene.Int(required=False)
+        has_labour = graphene.Boolean(required=False)
+        labour_constrained = graphene.Boolean(required=False)
+        excluded_programme_codes = graphene.List(graphene.String, required=False)
+        household_head_gender = graphene.Int(required=False)
+
+    @classmethod
+    def _validate_mutation(cls, user, **data):
+        if type(user) is AnonymousUser or not user.id or not user.has_perms(
+                MsrEtlConfig.gql_mutation_execute_msr_etl_rule_perms):
+            raise ValidationError("mutation.authentication_required")
+
+    @classmethod
+    def _mutate(cls, user, **data):
+        try:
+            data.pop('client_mutation_id', None)
+            data.pop('client_mutation_label', None)
+            service_kwargs = MsrEtlServiceMutation._get_supported_service_kwargs(
+                UBRIndividualService,
+                data,
+            )
+            result = UBRIndividualService(user, **service_kwargs).execute()
+
+            if result['success']:
+                return None
+
+            return [{
+                'message': result.get(
+                    'message',
+                    "msr_etl.mutation.failed_to_execute_ubr_individuals_import",
+                ),
+                'detail': result.get('detail'),
+            }]
+        except Exception as exc:
+            return [{
+                'message': "msr_etl.mutation.failed_to_execute_ubr_individuals_import",
+                'detail': str(exc),
+            }]
 
 
 class SaveMsrUbrIndividualsMutation(BaseMutation):

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -39,6 +39,10 @@ class MsrEtlServiceMutation(BaseMutation):
         gender = graphene.String(required=False)
         minAge = graphene.Int(required=False)
         maxAge = graphene.Int(required=False)
+        has_labour = graphene.Boolean(required=False)
+        labour_constrained = graphene.Boolean(required=False)
+        excluded_programme_codes = graphene.List(graphene.String, required=False)
+        household_head_gender = graphene.Int(required=False)
 
     @classmethod
     def _validate_mutation(cls, user, **data):

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -9,6 +9,7 @@ from msr_etl.gql_queries import (
     MsrUbrLocationsGQLType,
 )
 from msr_etl.gql_mutations import (
+    ExecuteMsrUbrIndividualsImportMutation,
     MsrEtlServiceMutation,
     SaveMsrUbrIndividualsMutation,
     SaveMsrUbrLocationsMutation,
@@ -155,5 +156,8 @@ class Query(graphene.ObjectType):
 
 class Mutation(graphene.ObjectType):
     execute_msr_etl_service = MsrEtlServiceMutation.Field()
+    execute_msr_ubr_individuals_import = (
+        ExecuteMsrUbrIndividualsImportMutation.Field()
+    )
     save_msr_ubr_individuals = SaveMsrUbrIndividualsMutation.Field()
     save_msr_ubr_locations = SaveMsrUbrLocationsMutation.Field()

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -40,6 +40,10 @@ class Query(graphene.ObjectType):
         gender=graphene.Argument(graphene.String, required=False),
         minAge=graphene.Argument(graphene.Int, required=False),
         maxAge=graphene.Argument(graphene.Int, required=False),
+        has_labour=graphene.Argument(graphene.Boolean, required=False),
+        labour_constrained=graphene.Argument(graphene.Boolean, required=False),
+        excluded_programme_codes=graphene.Argument(graphene.List(graphene.String), required=False),
+        household_head_gender=graphene.Argument(graphene.Int, required=False),
     )
 
     msr_ubr_locations = graphene.Field(
@@ -89,6 +93,10 @@ class Query(graphene.ObjectType):
         gender = kwargs.get("gender")
         min_age = kwargs.get("minAge")
         max_age = kwargs.get("maxAge")
+        has_labour = kwargs.get("has_labour")
+        labour_constrained = kwargs.get("labour_constrained")
+        excluded_programme_codes = kwargs.get("excluded_programme_codes")
+        household_head_gender = kwargs.get("household_head_gender")
 
         if lower_percentile_category is not None or upper_percentile_category is not None:
             lower = 0 if lower_percentile_category is None else lower_percentile_category
@@ -107,6 +115,10 @@ class Query(graphene.ObjectType):
             gender=gender,
             min_age=min_age,
             max_age=max_age,
+            has_labour=has_labour,
+            labour_constrained=labour_constrained,
+            excluded_programme_codes=excluded_programme_codes,
+            household_head_gender=household_head_gender,
         )
         individuals = source.fetch()
         return MsrUbrIndividualsGQLType(

--- a/msr_etl/services/base.py
+++ b/msr_etl/services/base.py
@@ -22,20 +22,39 @@ class MsrETLService(metaclass=abc.ABCMeta):
         self.sink = sink
 
     def execute(self):
+        batches_processed = 0
+        source_records = 0
+        transformed_records = 0
+        batch_identifiers = []
+
         try:
             for raw_batch, batch_identifier in self.source.pull():
+                batches_processed += 1
+                batch_identifiers.append(batch_identifier)
+                source_records += (
+                    len(raw_batch) if hasattr(raw_batch, "__len__") else 0
+                )
+
                 transformed_batch = self.adapter.transform(raw_batch)
+                transformed_records += (
+                    len(transformed_batch) if hasattr(transformed_batch, "__len__") else 0
+                )
                 self.sink.push(transformed_batch, batch_identifier)
         except Exception as e:
             logger.error("Error in ETL pipeline: %s", str(e), exc_info=e)
             return self._error_result(str(e))
 
-        return self._success_result()
+        return self._success_result({
+            "batches_processed": batches_processed,
+            "source_records": source_records,
+            "transformed_records": transformed_records,
+            "batch_identifiers": batch_identifiers,
+        })
 
     @staticmethod
     def _error_result(detail):
         return {"success": False, "message": "Failed to execute ETL pipeline", "detail": detail}
 
     @staticmethod
-    def _success_result():
-        return {"success": True, "data": None}
+    def _success_result(data=None):
+        return {"success": True, "data": data}

--- a/msr_etl/services/ubr_service.py
+++ b/msr_etl/services/ubr_service.py
@@ -19,6 +19,10 @@ class UBRIndividualService(MsrETLService):
                  gender: str = None,
                  minAge: int = None,
                  maxAge: int = None,
+                 has_labour: bool = None,
+                 labour_constrained: bool = None,
+                 excluded_programme_codes: list = None,
+                 household_head_gender: int = None,
                  source: DataSource = None,
                  adapter: DataAdapter = None,
                  sink: DataSink = None):
@@ -40,6 +44,10 @@ class UBRIndividualService(MsrETLService):
                 gender=gender,
                 min_age=minAge,
                 max_age=maxAge,
+                has_labour=has_labour,
+                labour_constrained=labour_constrained,
+                excluded_programme_codes=excluded_programme_codes,
+                household_head_gender=household_head_gender,
             ),
             adapter=adapter or UBRIndividualAdapter(),
             sink=sink or IndividualImportSink(user)

--- a/msr_etl/sinks/individual_import_sink.py
+++ b/msr_etl/sinks/individual_import_sink.py
@@ -15,11 +15,28 @@ WORKFLOW_GROUP = "individual"
 GROUP_AGGREGATION_COLUMN = None
 
 
+def ensure_import_user_login_name(user: User):
+    try:
+        login_name = getattr(user, 'login_name')
+    except AttributeError:
+        login_name = None
+
+    if login_name:
+        return user
+
+    username = getattr(user, 'username', None)
+    if not username:
+        raise AttributeError('User has no attribute login_name or username')
+
+    setattr(user, 'login_name', username)
+    return user
+
+
 class IndividualImportSink(DataSink):
 
     def __init__(self, user: User):
         super().__init__()
-        self.service = IndividualImportService(user)
+        self.service = IndividualImportService(ensure_import_user_login_name(user))
         self.import_new_workflow = self.get_workflow(IMPORT_NEW_INDIVIDUALS)
         self.update_existing_workflow = self.get_workflow(UPDATE_EXISTING_INDIVIDUALS)
 

--- a/msr_etl/sinks/individual_import_sink.py
+++ b/msr_etl/sinks/individual_import_sink.py
@@ -2,7 +2,7 @@ import logging
 from msr_etl.sinks import DataSink
 from msr_etl.utils import data_to_file
 from core.models import User
-from individual.models import Individual
+from individual.models import Individual, IndividualDataSourceUpload
 from individual.services import IndividualImportService
 from workflow.services import WorkflowService
 from msr_etl.apps import MsrEtlConfig
@@ -61,6 +61,7 @@ class IndividualImportSink(DataSink):
         result_new = self.service.import_individuals(
             import_file, self.import_new_workflow, GROUP_AGGREGATION_COLUMN
         )
+        self._raise_if_upload_failed(result_new, 'import')
         logger.debug(f"Imported {len(new_records)} new records with {result_new}")
 
     def _update_existing_records(self, existing_records, batch_identifier):
@@ -68,7 +69,24 @@ class IndividualImportSink(DataSink):
         result_existing = self.service.import_individuals(
             update_file, self.update_existing_workflow, GROUP_AGGREGATION_COLUMN
         )
+        self._raise_if_upload_failed(result_existing, 'update')
         logger.debug(f"Updated {len(existing_records)} existing records with {result_existing}")
+
+    def _raise_if_upload_failed(self, result: dict, action: str):
+        upload_uuid = (result or {}).get('data', {}).get('upload_uuid')
+        if not upload_uuid:
+            return
+
+        upload = (
+            IndividualDataSourceUpload.objects
+            .filter(uuid=upload_uuid)
+            .only('status', 'error')
+            .first()
+        )
+        if not upload or upload.status != IndividualDataSourceUpload.Status.FAIL:
+            return
+
+        raise self.Error(f"Individual {action} workflow failed: {upload.error}")
 
     def _split_existing_and_new(self, data: list[dict]) -> tuple[list[dict], list[dict]]:
         model_lookup_field = MsrEtlConfig.sink_model_lookup_field

--- a/msr_etl/sinks/individual_import_sink.py
+++ b/msr_etl/sinks/individual_import_sink.py
@@ -15,6 +15,17 @@ WORKFLOW_GROUP = "individual"
 GROUP_AGGREGATION_COLUMN = None
 
 
+def resolve_import_user(user: User):
+    username = MsrEtlConfig.sink_import_username
+    if username:
+        import_user = User.objects.filter(username=username).first()
+        if not import_user:
+            raise DataSink.Error(f"Configured sink_import_username not found: {username}")
+        return ensure_import_user_login_name(import_user)
+
+    return ensure_import_user_login_name(user)
+
+
 def ensure_import_user_login_name(user: User):
     try:
         login_name = getattr(user, 'login_name')
@@ -36,7 +47,7 @@ class IndividualImportSink(DataSink):
 
     def __init__(self, user: User):
         super().__init__()
-        self.service = IndividualImportService(ensure_import_user_login_name(user))
+        self.service = IndividualImportService(resolve_import_user(user))
         self.import_new_workflow = self.get_workflow(IMPORT_NEW_INDIVIDUALS)
         self.update_existing_workflow = self.get_workflow(UPDATE_EXISTING_INDIVIDUALS)
 

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -27,6 +27,10 @@ class UBRIndividualSource(DataSource):
         gender: str = None,
         min_age: int = None,
         max_age: int = None,
+        has_labour: bool = None,
+        labour_constrained: bool = None,
+        excluded_programme_codes: list = None,
+        household_head_gender: int = None,
     ):
         super().__init__()
 
@@ -47,6 +51,12 @@ class UBRIndividualSource(DataSource):
         self.gender = gender
         self.min_age = min_age
         self.max_age = max_age
+        self.has_labour = has_labour
+        self.labour_constrained = labour_constrained
+        self.excluded_programme_codes = [
+            str(code) for code in (excluded_programme_codes or [])
+        ]
+        self.household_head_gender = household_head_gender
 
     def pull(self):
         headers = {
@@ -129,7 +139,8 @@ class UBRIndividualSource(DataSource):
             logger.error(f"Error in response: {body.get('error_message')}")
             raise self.Error(f"Error in response: {body.get('error_message')}")
 
-        return body.get("targeting_data", [])
+        rows = body.get("targeting_data", [])
+        return self._apply_local_filters(rows)
 
     def _get_district_codes(self):
         if self.district:
@@ -175,6 +186,123 @@ class UBRIndividualSource(DataSource):
             raise self.Error(
                 f"Village code '{self.village}' was not found under TA '{ta_code}'."
             )
+
+    def _apply_local_filters(self, rows):
+        filtered = []
+
+        for row in rows:
+            if self.has_labour is not None:
+                if self._household_has_labour(row) != self.has_labour:
+                    continue
+
+            if self.labour_constrained is not None:
+                if self._household_is_labour_constrained(row) != self.labour_constrained:
+                    continue
+
+            if self.household_head_gender is not None:
+                if not self._household_head_gender_matches(row):
+                    continue
+
+            if self.excluded_programme_codes:
+                if self._household_has_excluded_programme(row):
+                    continue
+
+            filtered.append(row)
+
+        return filtered
+
+
+    def _household_has_labour(self, row):
+        summary = row.get("household_summary") or {}
+        members_fit_for_work = summary.get("members_fit_for_work")
+
+        try:
+            return int(members_fit_for_work or 0) > 0
+        except (TypeError, ValueError):
+            members = row.get("household_members") or []
+            return any(self._as_bool(member.get("fit_for_work")) for member in members)
+
+
+    def _household_is_labour_constrained(self, row):
+        summary = row.get("household_summary") or {}
+        return self._as_bool(summary.get("labour_constrained"))
+
+
+    def _household_head_gender_matches(self, row):
+        summary = row.get("household_summary") or {}
+        household_head_gender = summary.get("household_head_gender")
+
+        if household_head_gender is None:
+            return False
+
+        return str(household_head_gender) == str(self.household_head_gender)
+
+
+    def _household_has_excluded_programme(self, row):
+        programme_parameter_id = str(
+            getattr(MsrEtlConfig, "ubr_programme_parameter_id", 2) or 2
+        )
+        excluded_codes = set(self.excluded_programme_codes)
+
+        for response in self._as_list(row.get("household_combined_responses")):
+            general_parameter = response.get("general_parameter") or {}
+            if self._general_parameter_matches_programme(
+                general_parameter,
+                programme_parameter_id,
+                excluded_codes,
+            ):
+                return True
+
+        for programme in self._as_list(row.get("household_programmes")):
+            general_parameter = programme.get("general_parameter") or programme
+            if self._general_parameter_matches_programme(
+                general_parameter,
+                programme_parameter_id,
+                excluded_codes,
+            ):
+                return True
+
+        return False
+
+
+    @staticmethod
+    def _general_parameter_matches_programme(
+        general_parameter,
+        programme_parameter_id,
+        excluded_codes,
+    ):
+        if not general_parameter:
+            return False
+
+        return (
+            str(general_parameter.get("parameter_id")) == programme_parameter_id
+            and str(general_parameter.get("parameter_code")) in excluded_codes
+        )
+
+
+    @staticmethod
+    def _as_bool(value):
+        if isinstance(value, bool):
+            return value
+
+        if value is None:
+            return False
+
+        if isinstance(value, (int, float)):
+            return value == 1
+
+        return str(value).strip().lower() in ("1", "true", "yes", "y")
+
+
+    @staticmethod
+    def _as_list(value):
+        if value is None:
+            return []
+
+        if isinstance(value, list):
+            return value
+
+        return [value]
 
 
 class UBRLocationSource(DataSource):

--- a/msr_etl/tests/test_individual_import_sink.py
+++ b/msr_etl/tests/test_individual_import_sink.py
@@ -36,6 +36,40 @@ class TestIndividualImportSink(TestCase):
         mock_get_workflows.assert_any_call(IMPORT_NEW_INDIVIDUALS, WORKFLOW_GROUP)
         mock_get_workflows.assert_any_call(UPDATE_EXISTING_INDIVIDUALS, WORKFLOW_GROUP)
 
+    @patch('msr_etl.sinks.individual_import_sink.IndividualImportService')
+    @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
+    def test_init_adapts_user_without_login_name(self, mock_get_workflows, mock_import_service):
+        class TechnicalUserWrapper:
+            username = 'Yutaka'
+
+            def __getattr__(self, name):
+                if name == 'login_name':
+                    raise AttributeError('User has no attribute login_name')
+                raise AttributeError(name)
+
+        mock_get_workflows.side_effect = mock_get_workflow
+
+        IndividualImportSink(TechnicalUserWrapper())
+
+        service_user = mock_import_service.call_args[0][0]
+        self.assertEqual(service_user.login_name, 'Yutaka')
+        self.assertEqual(service_user.username, 'Yutaka')
+
+    @patch('msr_etl.sinks.individual_import_sink.IndividualImportService')
+    @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
+    def test_init_keeps_existing_login_name(self, mock_get_workflows, mock_import_service):
+        class InteractiveUserWrapper:
+            login_name = 'admin'
+            username = 'Yutaka'
+
+        mock_get_workflows.side_effect = mock_get_workflow
+
+        IndividualImportSink(InteractiveUserWrapper())
+
+        service_user = mock_import_service.call_args[0][0]
+        self.assertEqual(service_user.login_name, 'admin')
+        self.assertEqual(service_user.username, 'Yutaka')
+
     @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
     def test_init_no_workflow_found(self, mock_get_workflows):
         mock_get_workflows.return_value = {

--- a/msr_etl/tests/test_individual_import_sink.py
+++ b/msr_etl/tests/test_individual_import_sink.py
@@ -13,6 +13,7 @@ class TestIndividualImportSink(TestCase):
         self.user = LogInHelper().get_or_create_user_api()
         MsrEtlConfig.sink_model_lookup_field = 'json_ext__external_id'
         MsrEtlConfig.sink_update_existing = True
+        MsrEtlConfig.sink_import_username = ''
 
         # Create existing individual in the database
         self.individual = Individual(
@@ -69,6 +70,46 @@ class TestIndividualImportSink(TestCase):
         service_user = mock_import_service.call_args[0][0]
         self.assertEqual(service_user.login_name, 'admin')
         self.assertEqual(service_user.username, 'Yutaka')
+
+    @patch('msr_etl.sinks.individual_import_sink.User.objects')
+    @patch('msr_etl.sinks.individual_import_sink.IndividualImportService')
+    @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
+    def test_init_uses_configured_import_username(
+            self,
+            mock_get_workflows,
+            mock_import_service,
+            mock_user_objects,
+    ):
+        class ImportUserWrapper:
+            login_name = 'Admin'
+            username = 'Admin'
+
+        mock_get_workflows.side_effect = mock_get_workflow
+        mock_user_objects.filter.return_value.first.return_value = ImportUserWrapper()
+        MsrEtlConfig.sink_import_username = 'Admin'
+
+        IndividualImportSink(self.user)
+
+        service_user = mock_import_service.call_args[0][0]
+        mock_user_objects.filter.assert_called_once_with(username='Admin')
+        self.assertEqual(service_user.login_name, 'Admin')
+        self.assertEqual(service_user.username, 'Admin')
+
+    @patch('msr_etl.sinks.individual_import_sink.User.objects')
+    @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
+    def test_init_raises_when_configured_import_username_missing(
+            self,
+            mock_get_workflows,
+            mock_user_objects,
+    ):
+        mock_get_workflows.side_effect = mock_get_workflow
+        mock_user_objects.filter.return_value.first.return_value = None
+        MsrEtlConfig.sink_import_username = 'MissingUser'
+
+        with self.assertRaises(IndividualImportSink.Error) as context:
+            IndividualImportSink(self.user)
+
+        self.assertIn('Configured sink_import_username not found: MissingUser', str(context.exception))
 
     @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
     def test_init_no_workflow_found(self, mock_get_workflows):

--- a/msr_etl/tests/test_individual_import_sink.py
+++ b/msr_etl/tests/test_individual_import_sink.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from msr_etl.sinks.individual_import_sink import IndividualImportSink, IMPORT_NEW_INDIVIDUALS, UPDATE_EXISTING_INDIVIDUALS, WORKFLOW_GROUP
 from core.test_helpers import LogInHelper
-from individual.models import Individual
+from individual.models import Individual, IndividualDataSourceUpload
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from msr_etl.apps import MsrEtlConfig
 
@@ -137,6 +137,34 @@ class TestIndividualImportSink(TestCase):
         existing_content = existing_update_file.file.read().decode('utf-8')
         expected_existing_csv = f'external_id,name,age,ID\r\n123,John Doe,30,{self.individual.id}\r\n'
         self.assertEqual(existing_content, expected_existing_csv)
+
+    @patch('msr_etl.sinks.individual_import_sink.IndividualDataSourceUpload.objects')
+    @patch('msr_etl.sinks.individual_import_sink.IndividualImportService.import_individuals')
+    @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')
+    def test_push_raises_when_import_workflow_upload_failed(
+            self,
+            mock_get_workflows,
+            mock_import_individuals,
+            mock_upload_objects,
+    ):
+        mock_get_workflows.side_effect = mock_get_workflow
+        mock_import_individuals.return_value = {
+            'success': True,
+            'data': {'upload_uuid': '019f222d-5a49-72ac-b74d-0b9e3822b273'},
+        }
+        failed_upload = MagicMock(
+            status=IndividualDataSourceUpload.Status.FAIL,
+            error={'workflow': 'Uploaded individuals contains invalid columns'},
+        )
+        mock_upload_objects.filter.return_value.only.return_value.first.return_value = failed_upload
+
+        sink = IndividualImportSink(self.user)
+
+        with self.assertRaises(IndividualImportSink.Error) as context:
+            sink.push([{'external_id': 456, 'name': 'Jane Smith', 'age': 25}])
+
+        self.assertIn('Individual import workflow failed', str(context.exception))
+        self.assertIn('invalid columns', str(context.exception))
 
     @patch('msr_etl.sinks.individual_import_sink.IndividualImportService.import_individuals')
     @patch('msr_etl.sinks.individual_import_sink.WorkflowService.get_workflows')

--- a/msr_etl/tests/test_msr_etl_service.py
+++ b/msr_etl/tests/test_msr_etl_service.py
@@ -1,0 +1,44 @@
+from django.test import SimpleTestCase
+
+from msr_etl.services.base import MsrETLService
+
+
+class FakeSource:
+    def pull(self):
+        yield [{"id": 1}, {"id": 2}], "batch_one"
+        yield [{"id": 3}], "batch_two"
+
+
+class FakeAdapter:
+    def transform(self, data):
+        return [{"source_id": row["id"]} for row in data]
+
+
+class FakeSink:
+    def __init__(self):
+        self.pushed = []
+
+    def push(self, data, batch_identifier):
+        self.pushed.append((data, batch_identifier))
+
+
+class MsrETLServiceTestCase(SimpleTestCase):
+
+    def test_execute_returns_batch_and_record_summary(self):
+        sink = FakeSink()
+        service = MsrETLService(
+            source=FakeSource(),
+            adapter=FakeAdapter(),
+            sink=sink,
+        )
+
+        result = service.execute()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["data"], {
+            "batches_processed": 2,
+            "source_records": 3,
+            "transformed_records": 3,
+            "batch_identifiers": ["batch_one", "batch_two"],
+        })
+        self.assertEqual(len(sink.pushed), 2)

--- a/msr_etl/tests/test_ubr_import_mutation.py
+++ b/msr_etl/tests/test_ubr_import_mutation.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from msr_etl.gql_mutations import (
+    ExecuteMsrUbrIndividualsImportMutation,
+    MsrEtlServiceMutation,
+)
+from msr_etl.services import UBRIndividualService
+
+
+class ExecuteMsrUbrIndividualsImportMutationTestCase(SimpleTestCase):
+
+    def setUp(self):
+        self.user = MagicMock()
+        self.user.id = 1
+        self.user.has_perms.return_value = True
+        self.supported_filters = {
+            "district": "101",
+            "ta": "10101",
+            "village": "101010101",
+            "lower_percentile_category": 0,
+            "upper_percentile_category": 20,
+            "wealth_quintiles": [1, 2, 3],
+            "classification": [2],
+            "gender": "Female",
+            "minAge": 18,
+            "maxAge": 60,
+            "has_labour": True,
+            "labour_constrained": False,
+            "excluded_programme_codes": ["SCTP"],
+            "household_head_gender": 2,
+        }
+
+    def test_supported_service_kwargs_filters_to_ubr_individual_service_signature(self):
+        data = {
+            **self.supported_filters,
+            "client_mutation_id": "mutation-id",
+            "unsupported_value": "ignored",
+            "empty_value": None,
+        }
+
+        result = MsrEtlServiceMutation._get_supported_service_kwargs(
+            UBRIndividualService,
+            data,
+        )
+
+        self.assertEqual(result, self.supported_filters)
+
+    @patch("msr_etl.gql_mutations.MsrEtlServiceMutation._get_supported_service_kwargs")
+    @patch("msr_etl.gql_mutations.UBRIndividualService")
+    def test_mutation_executes_ubr_individual_service(self, mock_service_class, mock_supported_kwargs):
+        mock_supported_kwargs.return_value = self.supported_filters
+        service = mock_service_class.return_value
+        service.execute.return_value = {
+            "success": True,
+            "data": {
+                "batches_processed": 1,
+                "source_records": 2,
+                "transformed_records": 4,
+                "batch_identifiers": ["batch_101_10101_20260702000000"],
+            },
+        }
+
+        result = ExecuteMsrUbrIndividualsImportMutation.async_mutate(
+            self.user,
+            client_mutation_id="mutation-id",
+            client_mutation_label="MSR auto import",
+            unsupported_value="ignored",
+            **self.supported_filters,
+        )
+
+        self.assertIsNone(result)
+        mock_supported_kwargs.assert_called_once()
+        mock_service_class.assert_called_once_with(self.user, **self.supported_filters)
+        service.execute.assert_called_once_with()
+
+    @patch("msr_etl.gql_mutations.UBRIndividualService")
+    def test_mutation_returns_error_message_when_service_fails(self, mock_service_class):
+        service = mock_service_class.return_value
+        service.execute.return_value = {
+            "success": False,
+            "message": "Failed to execute ETL pipeline",
+            "detail": "UBR API unavailable",
+        }
+
+        result = ExecuteMsrUbrIndividualsImportMutation.async_mutate(
+            self.user,
+            district="101",
+        )
+
+        self.assertEqual(result, [{
+            "message": "Failed to execute ETL pipeline",
+            "detail": "UBR API unavailable",
+        }])
+
+    @patch("msr_etl.gql_mutations.UBRIndividualService")
+    def test_mutation_requires_execute_permission(self, mock_service_class):
+        self.user.has_perms.return_value = False
+
+        result = ExecuteMsrUbrIndividualsImportMutation.async_mutate(
+            self.user,
+            district="101",
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["message"],
+            "Failed to process ExecuteMsrUbrIndividualsImportMutation mutation",
+        )
+        mock_service_class.assert_not_called()


### PR DESCRIPTION
## Summary

Combines the UBR household eligibility filter work with the automatic UBR individuals import workflow in one review.

This PR adds UBR household eligibility filters to the MSR ETL pull flow, then exposes an executeMsrUbrIndividualsImport mutation for automatically importing filtered UBR households into the existing Individual import workflow. The mutation accepts the same UBR filters as preview, forwards supported arguments to UBRIndividualService, and preserves the existing OpenIMIS mutation/error handling pattern.

Also adds ETL execution summary counts internally and focused tests for filter extraction, mutation execution, service failure handling, permission rejection, and batch summary counts.

Supersedes #29.
Closes #30.

## Changes

- Adds labour availability filtering.
- Adds labour-constrained household filtering.
- Adds programme exclusion filtering using UBR general_parameter parameter_id/parameter_code.
- Adds household head gender filtering.
- Applies local filters after UBR targeting data is fetched.
- Exposes the filters through GraphQL query and generic ETL mutation/service flow.
- Adds executeMsrUbrIndividualsImport for automatic filtered UBR household import.
- Reuses the preview filter arguments for the import mutation.
- Adds internal ETL execution summary counts.
- Adds focused tests for the new mutation and service behavior.

## Validation

- python -m compileall msr_etl
- git diff --check
- python3 -m compileall -q msr_etl/gql_mutations.py msr_etl/schema.py msr_etl/services/base.py msr_etl/tests/test_ubr_import_mutation.py msr_etl/tests/test_msr_etl_service.py
- ../.venv/bin/python manage.py test msr_etl.tests.test_ubr_import_mutation msr_etl.tests.test_msr_etl_service --keepdb

## Note

A full msr_etl module test run could not start in the local environment because the configured PostgreSQL user does not have permission to create the Django test database.

Target branch: sprint/2026-07
