### PR TITLE
Fix missing GVH parameter in UBR household imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Use this query to fetch household records from UBR. The response contains raw UB
 
 ```graphql
 query FetchMsrUbrIndividuals(
-  $district: String
-  $ta: String
+  $district: String!
+  $ta: String!
+  $gvh: String
   $village: String
   $lowerPercentileCategory: Int
   $upperPercentileCategory: Int
@@ -100,6 +101,7 @@ query FetchMsrUbrIndividuals(
   msrUbrIndividuals(
     district: $district
     ta: $ta
+    gvh: $gvh
     village: $village
     lowerPercentileCategory: $lowerPercentileCategory
     upperPercentileCategory: $upperPercentileCategory
@@ -124,6 +126,7 @@ Example variables (narrowly targeted fetch):
 {
   "district": "101",
   "ta": "10101",
+  "gvh": "1010101",
   "village": "10101001",
   "lowerPercentileCategory": 0,
   "upperPercentileCategory": 20,
@@ -134,12 +137,13 @@ Example variables (narrowly targeted fetch):
 }
 ```
 
-**Location filters** (all optional — narrower scope = fewer API calls):
+**Location filters**:
 
 | Argument | Meaning | UBR param | Default |
 |----------|---------|-----------|---------|
-| `district` | District code | `district_code` | all active districts |
-| `ta` | Traditional authority code | `traditional_authority_code` | all TAs in district |
+| `district` | District code (required) | `district_code` | none |
+| `ta` | Traditional authority code (required) | `traditional_authority_code` | none |
+| `gvh` | Group Village Head code | `group_village_head_code` | not sent unless resolved from village |
 | `village` | Village code | `village_code` | all villages in TA |
 
 **Targeting filters** (all optional — forwarded directly to the UBR API):
@@ -166,9 +170,10 @@ Wealth quintile values:
 
 Backend behavior:
 
-- If no `district` is provided, the backend iterates all active openIMIS districts.
-- If no `ta` is provided, the backend iterates all active TAs under the district.
-- Each district/TA pair results in a separate UBR API call; the module sleeps 5 seconds between calls to avoid rate limiting.
+- `district` and `ta` are required for household queries and imports.
+- `gvh` and `village` are optional. When a village is provided without a GVH, the backend derives its active parent GVH.
+- When both `gvh` and `village` are provided, the backend verifies the complete District → TA → GVH → Village hierarchy.
+- Each import results in a UBR API call with all selected location relationship parameters.
 - `classification` takes precedence over `wealthQuintiles` when both are supplied.
 - Location codes are validated against active openIMIS `Location` records before any UBR API call is made.
 
@@ -272,6 +277,7 @@ mutation ExecuteMsrEtlService {
     nameOfService: "UBRIndividualService"
     district: "101"
     ta: "10101"
+    gvh: "1010101"
     village: "10101001"
     lowerPercentileCategory: 0
     upperPercentileCategory: 20

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Example variables (narrowly targeted fetch):
 |----------|---------|-----------|---------|
 | `district` | District code (required) | `district_code` | none |
 | `ta` | Traditional authority code (required) | `traditional_authority_code` | none |
-| `gvh` | Group Village Head code | `group_village_head_code` | not sent unless resolved from village |
+| `gvh` | Group Village Head code | `group_village_head_code` | not sent |
 | `village` | Village code | `village_code` | all villages in TA |
 
 **Targeting filters** (all optional — forwarded directly to the UBR API):
@@ -171,8 +171,9 @@ Wealth quintile values:
 Backend behavior:
 
 - `district` and `ta` are required for household queries and imports.
-- `gvh` and `village` are optional. When a village is provided without a GVH, the backend derives its active parent GVH.
+- `gvh` and `village` are optional, but a village can only be supplied together with its parent GVH.
 - When both `gvh` and `village` are provided, the backend verifies the complete District → TA → GVH → Village hierarchy.
+- Every outbound UBR location parameter comes from the frontend request; the backend validates but does not derive missing parameters.
 - Each import results in a UBR API call with all selected location relationship parameters.
 - `classification` takes precedence over `wealthQuintiles` when both are supplied.
 - Location codes are validated against active openIMIS `Location` records before any UBR API call is made.

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -33,6 +33,7 @@ class MsrEtlServiceMutation(BaseMutation):
         name_of_service = graphene.String(required=True)
         district = graphene.String(required=False)
         ta = graphene.String(required=False)
+        gvh = graphene.String(required=False)
         village = graphene.String(required=False)
         lower_percentile_category = graphene.Int(required=False)
         upper_percentile_category = graphene.Int(required=False)
@@ -104,8 +105,9 @@ class ExecuteMsrUbrIndividualsImportMutation(BaseMutation):
     _mutation_module = "msr_etl"
 
     class Input(OpenIMISMutation.Input):
-        district = graphene.String(required=False)
-        ta = graphene.String(required=False)
+        district = graphene.String(required=True)
+        ta = graphene.String(required=True)
+        gvh = graphene.String(required=False)
         village = graphene.String(required=False)
         lower_percentile_category = graphene.Int(required=False)
         upper_percentile_category = graphene.Int(required=False)

--- a/msr_etl/schema.py
+++ b/msr_etl/schema.py
@@ -34,8 +34,9 @@ class Query(graphene.ObjectType):
 
     msr_ubr_individuals = graphene.Field(
         MsrUbrIndividualsGQLType,
-        district=graphene.Argument(graphene.String, required=False),
-        ta=graphene.Argument(graphene.String, required=False),
+        district=graphene.Argument(graphene.String, required=True),
+        ta=graphene.Argument(graphene.String, required=True),
+        gvh=graphene.Argument(graphene.String, required=False),
         village=graphene.Argument(graphene.String, required=False),
         lower_percentile_category=graphene.Argument(graphene.Int, required=False),
         upper_percentile_category=graphene.Argument(graphene.Int, required=False),
@@ -118,6 +119,7 @@ class Query(graphene.ObjectType):
         source = UBRIndividualSource(
             district=kwargs.get("district"),
             ta=kwargs.get("ta"),
+            gvh=kwargs.get("gvh"),
             village=kwargs.get("village"),
             pmt_percentile_range=pmt_percentile_range,
             wealth_quintiles=wealth_quintiles,

--- a/msr_etl/services/ubr_service.py
+++ b/msr_etl/services/ubr_service.py
@@ -11,6 +11,7 @@ class UBRIndividualService(MsrETLService):
                  user: User,
                  district: str = None,
                  ta: str = None,
+                 gvh: str = None,
                  village: str = None,
                  lower_percentile_category: int = None,
                  upper_percentile_category: int = None,
@@ -26,6 +27,9 @@ class UBRIndividualService(MsrETLService):
                  source: DataSource = None,
                  adapter: DataAdapter = None,
                  sink: DataSink = None):
+        if not district or not ta:
+            raise ValueError("district and ta are required for UBR household imports")
+
         if lower_percentile_category is not None or upper_percentile_category is not None:
             lower = 0 if lower_percentile_category is None else lower_percentile_category
             upper = 100 if upper_percentile_category is None else upper_percentile_category
@@ -37,6 +41,7 @@ class UBRIndividualService(MsrETLService):
             source=source or UBRIndividualSource(
                 district=district,
                 ta=ta,
+                gvh=gvh,
                 village=village,
                 pmt_percentile_range=pmt_percentile_range,
                 wealth_quintiles=wealth_quintiles,

--- a/msr_etl/services/ubr_service.py
+++ b/msr_etl/services/ubr_service.py
@@ -29,6 +29,8 @@ class UBRIndividualService(MsrETLService):
                  sink: DataSink = None):
         if not district or not ta:
             raise ValueError("district and ta are required for UBR household imports")
+        if village and not gvh:
+            raise ValueError("gvh is required when village is provided")
 
         if lower_percentile_category is not None or upper_percentile_category is not None:
             lower = 0 if lower_percentile_category is None else lower_percentile_category

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -230,17 +230,15 @@ class UBRIndividualSource(DataSource):
             "traditional_authority_code": ta_code,
         }
 
-        gvh_code = self._get_gvh_code(ta_code) if self.gvh else None
+        if self.gvh:
+            self._validate_gvh_code(ta_code)
         if self.village:
-            village_gvh_code = self._get_village_gvh_code(ta_code)
-            if gvh_code and gvh_code != village_gvh_code:
-                raise self.Error(
-                    f"Village code '{self.village}' was not found under GVH '{gvh_code}'."
-                )
-            gvh_code = village_gvh_code
+            if not self.gvh:
+                raise self.Error("gvh is required when village is provided.")
+            self._validate_village_code(ta_code)
 
-        if gvh_code:
-            params["group_village_head_code"] = gvh_code
+        if self.gvh:
+            params["group_village_head_code"] = self.gvh
         if self.village:
             params["village_code"] = self.village
 
@@ -314,7 +312,7 @@ class UBRIndividualSource(DataSource):
             validity_to__isnull=True,
         ).values_list('code', flat=True)
 
-    def _get_gvh_code(self, ta_code):
+    def _validate_gvh_code(self, ta_code):
         if not Location.objects.filter(
             code=self.gvh,
             parent__code=ta_code,
@@ -327,13 +325,12 @@ class UBRIndividualSource(DataSource):
                 f"GVH code '{self.gvh}' was not found under TA '{ta_code}'."
             )
 
-        return self.gvh
-
-    def _get_village_gvh_code(self, ta_code):
+    def _validate_village_code(self, ta_code):
         # Village (type V) sits under a GVH (type W) which sits under the TA (type D),
-        # so validate the complete hierarchy and return the GVH required by the UBR API.
-        gvh_code = Location.objects.filter(
+        # so validate every relationship using the codes supplied by the frontend.
+        if not Location.objects.filter(
             code=self.village,
+            parent__code=self.gvh,
             parent__parent__code=ta_code,
             parent__parent__type='D',
             parent__parent__validity_to__isnull=True,
@@ -341,14 +338,11 @@ class UBRIndividualSource(DataSource):
             parent__validity_to__isnull=True,
             type='V',
             validity_to__isnull=True,
-        ).values_list('parent__code', flat=True).first()
-
-        if not gvh_code:
+        ).exists():
             raise self.Error(
-                f"Village code '{self.village}' was not found under TA '{ta_code}'."
+                f"Village code '{self.village}' was not found under GVH "
+                f"'{self.gvh}' and TA '{ta_code}'."
             )
-
-        return gvh_code
 
     def _apply_local_filters(self, rows):
         filtered = []

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -141,6 +141,7 @@ class UBRIndividualSource(DataSource):
         pmt_percentile_range: range = range(0, 11),
         district: str = None,
         ta: str = None,
+        gvh: str = None,
         village: str = None,
         wealth_quintiles: list = None,
         classification: list = None,
@@ -161,6 +162,7 @@ class UBRIndividualSource(DataSource):
         self.pmt_percentile_range = pmt_percentile_range
         self.district = district
         self.ta = ta
+        self.gvh = gvh
         self.village = village
         self.wealth_quintiles = wealth_quintiles or [
             UBRWealthQuintiles.POOREST.value,
@@ -226,10 +228,27 @@ class UBRIndividualSource(DataSource):
         params = {
             "district_code": district_code,
             "traditional_authority_code": ta_code,
+        }
+
+        gvh_code = self._get_gvh_code(ta_code) if self.gvh else None
+        if self.village:
+            village_gvh_code = self._get_village_gvh_code(ta_code)
+            if gvh_code and gvh_code != village_gvh_code:
+                raise self.Error(
+                    f"Village code '{self.village}' was not found under GVH '{gvh_code}'."
+                )
+            gvh_code = village_gvh_code
+
+        if gvh_code:
+            params["group_village_head_code"] = gvh_code
+        if self.village:
+            params["village_code"] = self.village
+
+        params.update({
             "lower_percentile_category": str(self.pmt_percentile_range.start),
             "upper_percentile_category": str(self.pmt_percentile_range.stop - 1),
             "wealth_quintile": ",".join([str(q) for q in self.wealth_quintiles]),
-        }
+        })
         if self.classification:
             params["wealth_quintile"] = ",".join([str(c) for c in self.classification])
         if self.gender:
@@ -238,10 +257,6 @@ class UBRIndividualSource(DataSource):
             params["minAge"] = str(self.min_age)
         if self.max_age is not None:
             params["maxAge"] = str(self.max_age)
-        if self.village:
-            gvh_code = self._get_village_gvh_code(ta_code)
-            params["group_village_head_code"] = gvh_code
-            params["village_code"] = self.village
 
         res = _post_with_resilience(
             session,
@@ -298,6 +313,21 @@ class UBRIndividualSource(DataSource):
             type='D',
             validity_to__isnull=True,
         ).values_list('code', flat=True)
+
+    def _get_gvh_code(self, ta_code):
+        if not Location.objects.filter(
+            code=self.gvh,
+            parent__code=ta_code,
+            parent__type='D',
+            parent__validity_to__isnull=True,
+            type='W',
+            validity_to__isnull=True,
+        ).exists():
+            raise self.Error(
+                f"GVH code '{self.gvh}' was not found under TA '{ta_code}'."
+            )
+
+        return self.gvh
 
     def _get_village_gvh_code(self, ta_code):
         # Village (type V) sits under a GVH (type W) which sits under the TA (type D),

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -239,7 +239,8 @@ class UBRIndividualSource(DataSource):
         if self.max_age is not None:
             params["maxAge"] = str(self.max_age)
         if self.village:
-            self._validate_village_code(ta_code)
+            gvh_code = self._get_village_gvh_code(ta_code)
+            params["group_village_head_code"] = gvh_code
             params["village_code"] = self.village
 
         res = _post_with_resilience(
@@ -298,18 +299,26 @@ class UBRIndividualSource(DataSource):
             validity_to__isnull=True,
         ).values_list('code', flat=True)
 
-    def _validate_village_code(self, ta_code):
+    def _get_village_gvh_code(self, ta_code):
         # Village (type V) sits under a GVH (type W) which sits under the TA (type D),
-        # so a village belongs to a TA via parent__parent.
-        if not Location.objects.filter(
+        # so validate the complete hierarchy and return the GVH required by the UBR API.
+        gvh_code = Location.objects.filter(
             code=self.village,
             parent__parent__code=ta_code,
+            parent__parent__type='D',
+            parent__parent__validity_to__isnull=True,
+            parent__type='W',
+            parent__validity_to__isnull=True,
             type='V',
             validity_to__isnull=True,
-        ).exists():
+        ).values_list('parent__code', flat=True).first()
+
+        if not gvh_code:
             raise self.Error(
                 f"Village code '{self.village}' was not found under TA '{ta_code}'."
             )
+
+        return gvh_code
 
     def _apply_local_filters(self, rows):
         filtered = []

--- a/msr_etl/tests/test_ubr_import_mutation.py
+++ b/msr_etl/tests/test_ubr_import_mutation.py
@@ -55,6 +55,18 @@ class ExecuteMsrUbrIndividualsImportMutationTestCase(SimpleTestCase):
         ):
             UBRIndividualService(self.user, district="101")
 
+    def test_ubr_individual_service_requires_gvh_with_village(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "gvh is required when village is provided",
+        ):
+            UBRIndividualService(
+                self.user,
+                district="101",
+                ta="10101",
+                village="101010101",
+            )
+
     @patch("msr_etl.gql_mutations.MsrEtlServiceMutation._get_supported_service_kwargs")
     @patch("msr_etl.gql_mutations.UBRIndividualService")
     def test_mutation_executes_ubr_individual_service(self, mock_service_class, mock_supported_kwargs):

--- a/msr_etl/tests/test_ubr_import_mutation.py
+++ b/msr_etl/tests/test_ubr_import_mutation.py
@@ -18,6 +18,7 @@ class ExecuteMsrUbrIndividualsImportMutationTestCase(SimpleTestCase):
         self.supported_filters = {
             "district": "101",
             "ta": "10101",
+            "gvh": "1010101",
             "village": "101010101",
             "lower_percentile_category": 0,
             "upper_percentile_category": 20,
@@ -46,6 +47,13 @@ class ExecuteMsrUbrIndividualsImportMutationTestCase(SimpleTestCase):
         )
 
         self.assertEqual(result, self.supported_filters)
+
+    def test_ubr_individual_service_requires_district_and_ta(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "district and ta are required",
+        ):
+            UBRIndividualService(self.user, district="101")
 
     @patch("msr_etl.gql_mutations.MsrEtlServiceMutation._get_supported_service_kwargs")
     @patch("msr_etl.gql_mutations.UBRIndividualService")

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -170,6 +170,7 @@ class UBRIndividualSourceTestCase(TestCase):
             pmt_percentile_range=range(1, 3),
             district="101",
             ta="10101",
+            gvh="1010101",
             village="10101001",
             wealth_quintiles=[2, 5],
             classification=[3],
@@ -198,6 +199,14 @@ class UBRIndividualSourceTestCase(TestCase):
         self.assertEqual(kwargs["params"]["maxAge"], "17")
         self.assertEqual(len(pulled_data), 1)
         self.assertTrue(identifiers[0].startswith("batch_101_10101_"))
+        mock_location_filter.assert_any_call(
+            code="1010101",
+            parent__code="10101",
+            parent__type="D",
+            parent__validity_to__isnull=True,
+            type="W",
+            validity_to__isnull=True,
+        )
         mock_location_filter.assert_any_call(
             code="10101001",
             parent__parent__code="10101",

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -155,8 +155,6 @@ class UBRIndividualSourceTestCase(TestCase):
         def filter_side_effect(*args, **kwargs):
             mock_qs = MagicMock()
             mock_qs.exists.return_value = True
-            if kwargs.get("type") == "V":
-                mock_qs.values_list.return_value.first.return_value = "1010101"
             return mock_qs
 
         mock_location_filter.side_effect = filter_side_effect
@@ -209,6 +207,7 @@ class UBRIndividualSourceTestCase(TestCase):
         )
         mock_location_filter.assert_any_call(
             code="10101001",
+            parent__code="1010101",
             parent__parent__code="10101",
             parent__parent__type="D",
             parent__parent__validity_to__isnull=True,

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -155,7 +155,8 @@ class UBRIndividualSourceTestCase(TestCase):
         def filter_side_effect(*args, **kwargs):
             mock_qs = MagicMock()
             mock_qs.exists.return_value = True
-            mock_qs.values_list.return_value = []
+            if kwargs.get("type") == "V":
+                mock_qs.values_list.return_value.first.return_value = "1010101"
             return mock_qs
 
         mock_location_filter.side_effect = filter_side_effect
@@ -187,6 +188,7 @@ class UBRIndividualSourceTestCase(TestCase):
         _, kwargs = mock_post.call_args
         self.assertEqual(kwargs["params"]["district_code"], "101")
         self.assertEqual(kwargs["params"]["traditional_authority_code"], "10101")
+        self.assertEqual(kwargs["params"]["group_village_head_code"], "1010101")
         self.assertEqual(kwargs["params"]["village_code"], "10101001")
         self.assertEqual(kwargs["params"]["lower_percentile_category"], "1")
         self.assertEqual(kwargs["params"]["upper_percentile_category"], "2")
@@ -196,6 +198,16 @@ class UBRIndividualSourceTestCase(TestCase):
         self.assertEqual(kwargs["params"]["maxAge"], "17")
         self.assertEqual(len(pulled_data), 1)
         self.assertTrue(identifiers[0].startswith("batch_101_10101_"))
+        mock_location_filter.assert_any_call(
+            code="10101001",
+            parent__parent__code="10101",
+            parent__parent__type="D",
+            parent__parent__validity_to__isnull=True,
+            parent__type="W",
+            parent__validity_to__isnull=True,
+            type="V",
+            validity_to__isnull=True,
+        )
 
     def test_fetch_households_ssl_error_has_actionable_message(self):
         source = UBRIndividualSource(get_auth_provider('noauth'))


### PR DESCRIPTION
## What changed

- Require District and Traditional Authority for UBR household query/import contracts.
- Accept optional GVH and Village parameters throughout GraphQL, service, and source layers.
- Preserve outbound location parameters in hierarchy order: `district_code`, `traditional_authority_code`, `group_village_head_code`, `village_code`.
- Validate active District → TA → GVH → Village relationships before calling UBR.
- Require a frontend-supplied GVH whenever Village is supplied.
- Reject inconsistent GVH/Village combinations instead of sending contradictory filters.
- Document the updated contract and extend regression coverage.

## Bug details / root cause

Village-scoped UBR imports sent District, TA, and Village but omitted the parent `group_village_head_code`. The source already traversed Village → GVH → TA for validation, but discarded the GVH before constructing the outbound request. Live comparison showed the complete hierarchy request returned promptly while the incomplete ETL request reached its read timeout.

## Frontend dependency

Paired frontend draft PR [openimis-fe-msr_etl_js#8](https://github.com/nlgfc2024/openimis-fe-msr_etl_js/pull/8) preserves type `W`, requires District/TA in the household import UI, and sends optional GVH/Village in hierarchy order.

## Impact

Household imports now use one explicit, validated location contract across frontend, GraphQL, service, local `Location` hierarchy, and the UBR API. Every outbound hierarchy parameter originates in the frontend request; the backend only validates the supplied relationships and never derives a missing request parameter.

## Validation

- `python -m compileall -q msr_etl` — passed.
- `manage.py test msr_etl.tests.test_ubr_import_mutation` — 6 passed.
- `git diff --check` — passed.
- The database-backed `test_ubr_source` suite could not initialize locally because PostgreSQL was unavailable; the updated request assertions are included for CI execution.
