### PR TITLE
Stream UBR imports in percentile chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ Default configuration is defined in `msr_etl/apps.py`:
   "source_timeout_seconds": 300,
   "source_retry_total": 3,
   "source_retry_backoff_factor": 1.0,
+  "source_percentile_chunk_size": 10,
+  "source_percentile_chunk_delay_seconds": 1.0,
   "source_verify_ssl": true,
   "source_ca_bundle_path": "",
-  "sink_model_lookup_field": "json_ext__external_id",
+  "sink_model_lookup_field": "json_ext__ubr_id",
   "sink_update_existing": true,
   "gql_query_msr_etl_rule_perms": ["953001"],
   "gql_mutation_execute_msr_etl_rule_perms": ["953002"]
@@ -71,6 +73,8 @@ Source transport settings:
 - `source_timeout_seconds`: request timeout for each pull call.
 - `source_retry_total`: total retry count for transient HTTP/network failures.
 - `source_retry_backoff_factor`: exponential retry backoff factor.
+- `source_percentile_chunk_size`: maximum inclusive percentile categories sent in one UBR household request.
+- `source_percentile_chunk_delay_seconds`: delay between consecutive percentile chunk requests.
 - `source_verify_ssl`: keep `true` in production to validate server certificates.
 - `source_ca_bundle_path`: optional path to a custom CA bundle file for environments using private/self-signed CA chains.
 
@@ -174,6 +178,9 @@ Backend behavior:
 - `gvh` and `village` are optional, but a village can only be supplied together with its parent GVH.
 - When both `gvh` and `village` are provided, the backend verifies the complete District → TA → GVH → Village hierarchy.
 - Every outbound UBR location parameter comes from the frontend request; the backend validates but does not derive missing parameters.
+- The requested percentile range is split into non-overlapping inclusive chunks before calling UBR. With the default size of `10`, `0–20` becomes `0–9`, `10–19`, and `20–20`.
+- Each successful percentile chunk is transformed and pushed immediately. Batch identifiers include the chunk bounds, and reruns use `json_ext__ubr_id` to distinguish existing individuals from new records.
+- A later chunk failure does not roll back earlier successful workflow imports; the failed chunk bounds are included in the ETL error so the operation can be diagnosed and safely rerun.
 - Each import results in a UBR API call with all selected location relationship parameters.
 - `classification` takes precedence over `wealthQuintiles` when both are supplied.
 - Location codes are validated against active openIMIS `Location` records before any UBR API call is made.

--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -15,6 +15,8 @@ DEFAULT_CONFIG = {
     "source_timeout_seconds": 300,
     "source_retry_total": 3,
     "source_retry_backoff_factor": 1.0,
+    "source_percentile_chunk_size": 10,
+    "source_percentile_chunk_delay_seconds": 1.0,
     "source_verify_ssl": True,
     "source_ca_bundle_path": "",
 
@@ -26,7 +28,7 @@ DEFAULT_CONFIG = {
     "adapter_location_name_field": "locationName",
     "adapter_location_code_field": "locationCode",
 
-    "sink_model_lookup_field": "json_ext__external_id",
+    "sink_model_lookup_field": "json_ext__ubr_id",
     "sink_update_existing": True,
     "sink_import_username": "",
 
@@ -51,6 +53,8 @@ class MsrEtlConfig(AppConfig):
     source_timeout_seconds = None
     source_retry_total = None
     source_retry_backoff_factor = None
+    source_percentile_chunk_size = None
+    source_percentile_chunk_delay_seconds = None
     source_verify_ssl = None
     source_ca_bundle_path = None
 

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -73,6 +73,17 @@ def _get_retry_backoff_factor():
     return max(_get_float_config(MsrEtlConfig.source_retry_backoff_factor, 1.0), 0.0)
 
 
+def _get_percentile_chunk_size():
+    return max(_get_int_config(MsrEtlConfig.source_percentile_chunk_size, 10), 1)
+
+
+def _get_percentile_chunk_delay_seconds():
+    return max(
+        _get_float_config(MsrEtlConfig.source_percentile_chunk_delay_seconds, 1.0),
+        0.0,
+    )
+
+
 def _get_ssl_verify_setting():
     verify_ssl = _get_bool_config(MsrEtlConfig.source_verify_ssl, True)
     ca_bundle_path = str(MsrEtlConfig.source_ca_bundle_path or "").strip()
@@ -155,7 +166,12 @@ class UBRIndividualSource(DataSource):
     ):
         super().__init__()
 
-        if not (pmt_percentile_range.start >= 0 and pmt_percentile_range.stop <= 101):
+        if (
+            pmt_percentile_range.step != 1
+            or pmt_percentile_range.start < 0
+            or pmt_percentile_range.stop > 101
+            or pmt_percentile_range.start >= pmt_percentile_range.stop
+        ):
             raise self.Error("pmt_percentile_range must be between 0 and 100 inclusive.")
 
         self.auth_provider = auth_provider or get_auth_provider()
@@ -191,22 +207,29 @@ class UBRIndividualSource(DataSource):
 
         session = _create_retry_session()
 
-        district_codes = self._get_district_codes()
-
-        for district_code in district_codes:
-            ta_codes = self._get_ta_codes(district_code)
-
-            for ta_code in ta_codes:
-                rows = self.fetch_households(session, url, headers, district_code, ta_code)
-                if rows:
-                    prefix = f"batch_{district_code}_{ta_code}_"
-                    identifier = get_timestamped_batch_identifier(prefix)
-                    logger.info(f"Sending {len(rows)} records to data adaptor to process")
-                    yield rows, identifier
-
-                # Add a 5-second sleep after processing each TA
-                logger.info(f"Sleeping for 5 seconds after processing TA: {ta_code}")
-                time.sleep(5)
+        for rows, district_code, ta_code, chunk_lower, chunk_upper in (
+            self._iter_fetched_percentile_chunks(
+                session,
+                url,
+                headers,
+                sleep_after_ta=True,
+            )
+        ):
+            if not rows:
+                continue
+            prefix = (
+                f"batch_{district_code}_{ta_code}_"
+                f"pmt_{chunk_lower}_{chunk_upper}_"
+            )
+            identifier = get_timestamped_batch_identifier(prefix)
+            logger.info(
+                "Sending %s records for percentile chunk %s-%s "
+                "to data adaptor to process",
+                len(rows),
+                chunk_lower,
+                chunk_upper,
+            )
+            yield rows, identifier
 
     def fetch(self):
         headers = {
@@ -217,13 +240,77 @@ class UBRIndividualSource(DataSource):
         session = _create_retry_session()
 
         rows = []
-        for district_code in self._get_district_codes():
-            for ta_code in self._get_ta_codes(district_code):
-                rows.extend(self.fetch_households(session, url, headers, district_code, ta_code))
+        for chunk_rows, _, _, _, _ in self._iter_fetched_percentile_chunks(
+            session,
+            url,
+            headers,
+        ):
+            rows.extend(chunk_rows)
         return rows
 
-    def fetch_households(self, session, url, headers, district_code, ta_code):
+    def _iter_fetched_percentile_chunks(
+        self,
+        session,
+        url,
+        headers,
+        sleep_after_ta=False,
+    ):
+        percentile_chunks = list(self._iter_percentile_chunks())
+        seen_households = set()
+
+        for district_code in self._get_district_codes():
+            for ta_code in self._get_ta_codes(district_code):
+                for chunk_index, percentile_chunk in enumerate(percentile_chunks):
+                    chunk_lower = percentile_chunk.start
+                    chunk_upper = percentile_chunk.stop - 1
+                    try:
+                        rows = self.fetch_households(
+                            session,
+                            url,
+                            headers,
+                            district_code,
+                            ta_code,
+                            pmt_percentile_range=percentile_chunk,
+                        )
+                    except self.Error as exc:
+                        raise self.Error(
+                            f"UBR percentile chunk {chunk_lower}-{chunk_upper} failed: {exc}"
+                        ) from exc
+
+                    yield (
+                        self._deduplicate_households(rows, seen_households),
+                        district_code,
+                        ta_code,
+                        chunk_lower,
+                        chunk_upper,
+                    )
+
+                    if chunk_index < len(percentile_chunks) - 1:
+                        self._sleep_between_percentile_chunks(
+                            district_code,
+                            ta_code,
+                            chunk_lower,
+                            chunk_upper,
+                        )
+
+                if sleep_after_ta:
+                    logger.info(
+                        "Sleeping for 5 seconds after processing TA: %s",
+                        ta_code,
+                    )
+                    time.sleep(5)
+
+    def fetch_households(
+        self,
+        session,
+        url,
+        headers,
+        district_code,
+        ta_code,
+        pmt_percentile_range=None,
+    ):
         logger.debug(f"Fetching data for district: {district_code}, TA: {ta_code}")
+        percentile_range = pmt_percentile_range or self.pmt_percentile_range
 
         params = {
             "district_code": district_code,
@@ -243,8 +330,8 @@ class UBRIndividualSource(DataSource):
             params["village_code"] = self.village
 
         params.update({
-            "lower_percentile_category": str(self.pmt_percentile_range.start),
-            "upper_percentile_category": str(self.pmt_percentile_range.stop - 1),
+            "lower_percentile_category": str(percentile_range.start),
+            "upper_percentile_category": str(percentile_range.stop - 1),
             "wealth_quintile": ",".join([str(q) for q in self.wealth_quintiles]),
         })
         if self.classification:
@@ -275,6 +362,61 @@ class UBRIndividualSource(DataSource):
 
         rows = body.get("targeting_data", [])
         return self._apply_local_filters(rows)
+
+    def _iter_percentile_chunks(self):
+        chunk_size = _get_percentile_chunk_size()
+        requested_upper = self.pmt_percentile_range.stop - 1
+        chunk_lower = self.pmt_percentile_range.start
+
+        while chunk_lower <= requested_upper:
+            chunk_upper = min(chunk_lower + chunk_size - 1, requested_upper)
+            yield range(chunk_lower, chunk_upper + 1)
+            chunk_lower = chunk_upper + 1
+
+    @staticmethod
+    def _deduplicate_households(rows, seen_households):
+        unique_rows = []
+        for row in rows:
+            identity = UBRIndividualSource._get_household_identity(row)
+            if identity is not None:
+                if identity in seen_households:
+                    logger.warning(
+                        "Skipping duplicate UBR household across percentile chunks: %s",
+                        identity,
+                    )
+                    continue
+                seen_households.add(identity)
+            unique_rows.append(row)
+        return unique_rows
+
+    @staticmethod
+    def _get_household_identity(row):
+        for field in ("id", "form_number", "household_code"):
+            value = row.get(field)
+            if value not in (None, ""):
+                return field, str(value)
+        return None
+
+    @staticmethod
+    def _sleep_between_percentile_chunks(
+        district_code,
+        ta_code,
+        chunk_lower,
+        chunk_upper,
+    ):
+        delay_seconds = _get_percentile_chunk_delay_seconds()
+        if delay_seconds <= 0:
+            return
+        logger.info(
+            "Sleeping for %s seconds after UBR percentile chunk %s-%s "
+            "(district=%s, TA=%s)",
+            delay_seconds,
+            chunk_lower,
+            chunk_upper,
+            district_code,
+            ta_code,
+        )
+        time.sleep(delay_seconds)
 
     def _get_district_codes(self):
         # Malawi hierarchy: District = Location type R, TA = type D, GVH = type W, Village = type V.

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -1,8 +1,9 @@
 import logging
 from unittest.mock import patch, MagicMock
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
+from msr_etl.apps import MsrEtlConfig
 from msr_etl.auth_provider import get_auth_provider
 from msr_etl.sources import UBRIndividualSource, UBRLocationSource
 import requests
@@ -24,7 +25,7 @@ MOCKED_UBR_RESPONSE_DATA = [
 ]
 
 
-class UBRIndividualSourceTestCase(TestCase):
+class UBRIndividualSourceTestCase(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -77,12 +78,12 @@ class UBRIndividualSourceTestCase(TestCase):
         """
         # Setup the filter mock to return different codes based on the filter arguments
         def filter_side_effect(*args, **kwargs):
-            if kwargs.get("type") == "D":
+            if kwargs.get("type") == "R":
                 # Districts
                 mock_qs = MagicMock()
                 mock_qs.values_list.return_value = self.mocked_district_codes
                 return mock_qs
-            elif kwargs.get("type") == "W":
+            elif kwargs.get("type") == "D":
                 # TAs for district
                 mock_qs = MagicMock()
                 mock_qs.values_list.return_value = self.mocked_ta_codes
@@ -233,6 +234,121 @@ class UBRIndividualSourceTestCase(TestCase):
                 district_code="101",
                 ta_code="10101",
             )
+
+    @patch.object(MsrEtlConfig, "source_percentile_chunk_size", 10)
+    def test_percentile_chunks_are_inclusive_and_non_overlapping(self):
+        source = UBRIndividualSource(
+            get_auth_provider('noauth'),
+            pmt_percentile_range=range(0, 101),
+        )
+
+        chunks = [
+            (chunk.start, chunk.stop - 1)
+            for chunk in source._iter_percentile_chunks()
+        ]
+
+        self.assertEqual(chunks, [
+            (0, 9),
+            (10, 19),
+            (20, 29),
+            (30, 39),
+            (40, 49),
+            (50, 59),
+            (60, 69),
+            (70, 79),
+            (80, 89),
+            (90, 99),
+            (100, 100),
+        ])
+
+    @patch.object(MsrEtlConfig, "source_percentile_chunk_delay_seconds", 0)
+    @patch.object(MsrEtlConfig, "source_percentile_chunk_size", 10)
+    @patch("time.sleep")
+    @patch("requests.Session.post")
+    @patch("location.models.Location.objects.filter")
+    def test_pull_streams_chunks_and_deduplicates_households(
+        self,
+        mock_location_filter,
+        mock_post,
+        mock_sleep,
+    ):
+        location_qs = MagicMock()
+        location_qs.exists.return_value = True
+        mock_location_filter.return_value = location_qs
+        mock_post.side_effect = [
+            MagicMock(ok=True, json=MagicMock(return_value={
+                "error_occurred": False,
+                "targeting_data": [{"id": 1}, {"id": 2}],
+            })),
+            MagicMock(ok=True, json=MagicMock(return_value={
+                "error_occurred": False,
+                "targeting_data": [{"id": 2}, {"id": 3}],
+            })),
+            MagicMock(ok=True, json=MagicMock(return_value={
+                "error_occurred": False,
+                "targeting_data": [{"id": 4}],
+            })),
+        ]
+
+        source = UBRIndividualSource(
+            get_auth_provider('noauth'),
+            pmt_percentile_range=range(0, 21),
+            district="101",
+            ta="10101",
+        )
+
+        results = list(source.pull())
+
+        self.assertEqual(
+            [[row["id"] for row in rows] for rows, _ in results],
+            [[1, 2], [3], [4]],
+        )
+        self.assertEqual(
+            [
+                (
+                    call.kwargs["params"]["lower_percentile_category"],
+                    call.kwargs["params"]["upper_percentile_category"],
+                )
+                for call in mock_post.call_args_list
+            ],
+            [("0", "9"), ("10", "19"), ("20", "20")],
+        )
+        self.assertTrue(results[0][1].startswith("batch_101_10101_pmt_0_9_"))
+        self.assertTrue(results[1][1].startswith("batch_101_10101_pmt_10_19_"))
+        self.assertTrue(results[2][1].startswith("batch_101_10101_pmt_20_20_"))
+        mock_sleep.assert_called_once_with(5)
+
+    @patch.object(MsrEtlConfig, "source_percentile_chunk_delay_seconds", 0)
+    @patch.object(MsrEtlConfig, "source_percentile_chunk_size", 10)
+    @patch("requests.Session.post")
+    @patch("location.models.Location.objects.filter")
+    def test_pull_error_identifies_failed_percentile_chunk(
+        self,
+        mock_location_filter,
+        mock_post,
+    ):
+        location_qs = MagicMock()
+        location_qs.exists.return_value = True
+        mock_location_filter.return_value = location_qs
+        mock_post.side_effect = [
+            MagicMock(ok=True, json=MagicMock(return_value={
+                "error_occurred": False,
+                "targeting_data": [{"id": 1}],
+            })),
+            requests.exceptions.ReadTimeout("UBR read timed out"),
+        ]
+        source = UBRIndividualSource(
+            get_auth_provider('noauth'),
+            pmt_percentile_range=range(0, 21),
+            district="101",
+            ta="10101",
+        )
+
+        with self.assertRaisesRegex(
+            source.Error,
+            "percentile chunk 10-19 failed",
+        ):
+            list(source.pull())
 
 
 class UBRLocationSourceTestCase(TestCase):


### PR DESCRIPTION
## What changed

- Split inclusive percentile ranges into configurable, non-overlapping chunks using `source_percentile_chunk_size` (default: `10`).
- Stream each successful chunk through the ETL pipeline immediately instead of waiting for the full percentile range.
- Preserve every frontend-provided filter and location parameter on every UBR request.
- Include percentile bounds in batch identifiers and failure messages.
- Deduplicate households repeated across percentile chunks using stable UBR identifiers.
- Add a configurable delay between requests with `source_percentile_chunk_delay_seconds` (default: `1.0`).
- Use `json_ext__ubr_id` as the default sink lookup field so reruns can identify previously imported UBR individuals.
- Apply the same chunking behavior to preview fetches.

## Bug details

Large percentile spans, especially `0-100`, can make the UBR endpoint perform a long-running query and return a large response. That causes the backend request to exceed its read timeout even though narrower requests complete successfully.

The ETL previously submitted the entire percentile span as one request. A timeout therefore failed the whole pull before any response could be processed.

## Implemented behavior

Percentile bounds remain inclusive. For example:

- `0-20` becomes `0-9`, `10-19`, and `20-20`
- `0-100` becomes eleven requests, ending with `100-100`

Each successful response is yielded immediately to the normal transform and sink stages. If a later chunk fails, the error identifies that chunk and data from completed chunks remains committed. Rerunning the import uses the stable UBR ID lookup to update or skip records already processed, while in-run deduplication protects against overlapping records returned at chunk boundaries.

All request parameters supplied by the frontend, including the complete District → TA → GVH → Village hierarchy, are retained; only the percentile bounds change per request.

## Configuration

- `source_percentile_chunk_size`: default `10`, minimum `1`
- `source_percentile_chunk_delay_seconds`: default `1.0`, minimum `0`

Existing stored module configuration can override defaults. Deployments should confirm that `sink_model_lookup_field` is set to `json_ext__ubr_id` if it was previously persisted with another value.

## Dependency

This PR is intentionally stacked on `fix/missing_param_ubr_import` / backend PR #36 because it relies on the corrected location hierarchy parameters.

## Validation

- 13 focused source, mutation, and ETL service tests pass.
- Python compilation passes.
- Git whitespace validation passes.
