### PR TITLE
Fix empty UBR districts in CoreMIS location import

### DIFF
--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -629,10 +629,6 @@ class UBRLocationSource(DataSource):
             session, url, headers, {"geo_location_type_id": 1}, "districts"
         )
 
-        prefix = "batch_districts_"
-        identifier = get_timestamped_batch_identifier(prefix)
-        yield {"data_type": "D", "data": district_rows}, identifier
-
         for district in district_rows:
             district_code = district.get("geo_location_code")
             if not district_code:
@@ -643,6 +639,17 @@ class UBRLocationSource(DataSource):
             ta_rows = self.fetch_geo_locations_from_api(
                 session, url, headers, {"geo_location_type_id": 2, "district_code": district_code}, "TAs"
             )
+
+            if not ta_rows:
+                logger.warning(
+                    "Skipping district %s because UBR returned no TAs",
+                    district_code,
+                )
+                continue
+
+            prefix = f"batch_district_{district_code}_"
+            identifier = get_timestamped_batch_identifier(prefix)
+            yield {"data_type": "D", "data": [district]}, identifier
 
             prefix = f"batch_tas_{district_code}_"
             identifier = get_timestamped_batch_identifier(prefix)

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -458,8 +458,9 @@ class UBRLocationSourceTestCase(TestCase):
         self.assertEqual(villages[0]["geo_location_code"], "101010101")
         self.assertEqual(villages[1]["geo_location_code"], "101010102")
 
+    @patch("msr_etl.sources.ubr_source.time.sleep")
     @patch("requests.Session.post")
-    def test_pull(self, mock_post):
+    def test_pull(self, mock_post, mock_sleep):
         # Mock the API responses for districts, TAs, and villages
         mock_post.side_effect = [
             MagicMock(ok=True, json=MagicMock(return_value=self.mocked_districts_response)),  # Districts
@@ -476,20 +477,75 @@ class UBRLocationSourceTestCase(TestCase):
         results = list(source.pull())
 
         # Assertions
-        self.assertEqual(len(results), 7)  # 1 for districts, 2 for TAs, 2 for GVHs, 2 for villages
+        self.assertEqual(len(results), 8)  # 2 districts, 2 TAs, 2 GVHs, 2 villages
         self.assertEqual(results[0][0]["data_type"], "D")
         self.assertEqual(results[1][0]["data_type"], "T")
         self.assertEqual(results[2][0]["data_type"], "G")
         self.assertEqual(results[3][0]["data_type"], "V")
-        self.assertEqual(results[4][0]["data_type"], "T")
-        self.assertEqual(results[5][0]["data_type"], "G")
-        self.assertEqual(results[6][0]["data_type"], "V")
+        self.assertEqual(results[4][0]["data_type"], "D")
+        self.assertEqual(results[5][0]["data_type"], "T")
+        self.assertEqual(results[6][0]["data_type"], "G")
+        self.assertEqual(results[7][0]["data_type"], "V")
 
         # Check the number of records in each result
-        self.assertEqual(len(results[0][0]["data"]), 2)  # Districts
+        self.assertEqual(len(results[0][0]["data"]), 1)  # District 101
         self.assertEqual(len(results[1][0]["data"]), 2)  # TAs for District 101
         self.assertEqual(len(results[2][0]["data"]), 2)  # GVHs for District 101
         self.assertEqual(len(results[3][0]["data"]), 2)  # Villages for District 101
-        self.assertEqual(len(results[4][0]["data"]), 2)  # TAs for District 102
-        self.assertEqual(len(results[5][0]["data"]), 2)  # GVHs for District 102
-        self.assertEqual(len(results[6][0]["data"]), 2)  # Villages for District 102
+        self.assertEqual(len(results[4][0]["data"]), 1)  # District 102
+        self.assertEqual(len(results[5][0]["data"]), 2)  # TAs for District 102
+        self.assertEqual(len(results[6][0]["data"]), 2)  # GVHs for District 102
+        self.assertEqual(len(results[7][0]["data"]), 2)  # Villages for District 102
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("msr_etl.sources.ubr_source.time.sleep")
+    @patch("requests.Session.post")
+    def test_pull_skips_district_and_children_when_no_tas(
+        self,
+        mock_post,
+        mock_sleep,
+    ):
+        empty_tas_response = {
+            "error_occurred": False,
+            "total_records": 0,
+            "geo_locations": [],
+        }
+        mock_post.side_effect = [
+            MagicMock(
+                ok=True,
+                json=MagicMock(return_value=self.mocked_districts_response),
+            ),
+            MagicMock(ok=True, json=MagicMock(return_value=empty_tas_response)),
+            MagicMock(
+                ok=True,
+                json=MagicMock(return_value=self.mocked_tas_response[1]),
+            ),
+            MagicMock(
+                ok=True,
+                json=MagicMock(return_value=self.mocked_gvhs_response[1]),
+            ),
+            MagicMock(
+                ok=True,
+                json=MagicMock(return_value=self.mocked_villages_response[1]),
+            ),
+        ]
+
+        results = list(UBRLocationSource(get_auth_provider("noauth")).pull())
+
+        self.assertEqual(
+            [batch["data_type"] for batch, _identifier in results],
+            ["D", "T", "G", "V"],
+        )
+        self.assertEqual(results[0][0]["data"][0]["geo_location_code"], "102")
+        requested_params = [
+            call.kwargs["json"] for call in mock_post.call_args_list
+        ]
+        self.assertNotIn(
+            {"geo_location_type_id": 4, "district_code": "101"},
+            requested_params,
+        )
+        self.assertNotIn(
+            {"geo_location_type_id": 11, "district_code": "101"},
+            requested_params,
+        )
+        mock_sleep.assert_called_once_with(30)


### PR DESCRIPTION
## What changed

- Fetch TAs before yielding each UBR district during the full location pull.
- Skip a district completely when UBR returns no TAs.
- Avoid GVH and village requests, persistence batches, and the post-district sleep for skipped districts.
- Yield eligible districts individually before their TA batch so the existing parent-first CoreMIS hierarchy remains intact.
- Add regression coverage for mixed valid and empty districts, request suppression, batch ordering, and sleep behavior.

## Root cause

The source previously yielded all districts as one batch before fetching their children. The location adapter mapped those rows to CoreMIS regions (`R`), so districts with no TAs were saved even though they could never produce a usable downstream hierarchy.

## Impact

CoreMIS will no longer create new empty district-as-region records during a full UBR location pull. Empty districts are cheaper to process because their GVH/village calls and 30-second sleep are skipped. Existing empty records are not deleted by this change.

## Validation

- `python -m py_compile msr_etl/sources/ubr_source.py msr_etl/tests/test_ubr_source.py` — passed using the project virtual environment.
- `git diff --check` — passed.
- Targeted Django tests were discovered, but could not start locally because the configured PostgreSQL test database service was unavailable; CI should run the database-backed suite.
