### PR TITLE
Add crash-recovery sweeper and staging retention cleanup

### DIFF
--- a/msr_etl/scheduled_tasks.py
+++ b/msr_etl/scheduled_tasks.py
@@ -1,0 +1,115 @@
+import logging
+from datetime import timedelta
+
+from apscheduler.triggers.interval import IntervalTrigger
+from django.utils import timezone
+
+from core.models import AsyncJob
+from core.services import ProgressReporter
+from msr_etl.apps import MsrEtlConfig
+from msr_etl.models import MsrEtlSyncUnit
+from msr_etl.staging import job_has_failed_units, sync_staged_units
+
+logger = logging.getLogger(__name__)
+
+
+def schedule_tasks(scheduler):
+    sweep_minutes = max(int(MsrEtlConfig.sync_sweep_interval_minutes), 1)
+    scheduler.add_job(
+        sweep_sync_units,
+        trigger=IntervalTrigger(minutes=sweep_minutes),
+        id="msr_etl_sweep_sync_units",
+        max_instances=1,
+        replace_existing=True,
+    )
+    logger.info("Scheduled msr_etl sync unit sweeper every %s minutes", sweep_minutes)
+
+    scheduler.add_job(
+        cleanup_staged_payloads,
+        trigger=IntervalTrigger(hours=1),
+        id="msr_etl_cleanup_staged_payloads",
+        max_instances=1,
+        replace_existing=True,
+    )
+    logger.info("Scheduled msr_etl staged payload cleanup hourly")
+
+
+def sweep_sync_units():
+    """Crash recovery only. select_for_update(skip_locked=True) in
+    sync_staged_units makes this safe to run alongside a still-live job."""
+    _requeue_retryable_failed_units()
+    _sync_orphaned_units()
+    _close_completed_jobs()
+    _fail_stale_jobs()
+
+
+def _requeue_retryable_failed_units():
+    max_attempts = int(MsrEtlConfig.sync_unit_max_attempts)
+    MsrEtlSyncUnit.objects.filter(
+        stage_status=MsrEtlSyncUnit.Status.STAGED,
+        sync_status=MsrEtlSyncUnit.Status.FAILED,
+        attempts__lt=max_attempts,
+    ).update(sync_status=MsrEtlSyncUnit.Status.PENDING, updated_at=timezone.now())
+
+
+def _sync_orphaned_units():
+    """Reconstructs a ProgressReporter per job so retried units still
+    advance processed/metrics, which _close_completed_jobs relies on."""
+    job_uuids = (
+        MsrEtlSyncUnit.objects
+        .filter(stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING)
+        .values_list("job_uuid", flat=True)
+        .distinct()
+    )
+    for job_uuid in job_uuids:
+        job = AsyncJob.objects.filter(id=job_uuid).first()
+        if job is None:
+            continue
+        reporter = ProgressReporter(job) if job.total is not None else None
+        sync_staged_units(job_uuid, reporter=reporter, user=job.user)
+
+
+def _close_completed_jobs():
+    """A targeted status update() only - never touches processed/metrics.
+    processed >= total, not ==, since a retried unit advances twice."""
+    open_jobs = AsyncJob.objects.filter(
+        module="msr_etl",
+    ).exclude(status__in=AsyncJob.TERMINAL_STATUSES).exclude(total__isnull=True)
+
+    for job in open_jobs:
+        if job.processed < job.total:
+            continue
+        fields = {"finished_at": timezone.now(), "updated_at": timezone.now()}
+        if job_has_failed_units(job.id):
+            fields["status"] = AsyncJob.Status.PARTIAL
+            fields["error"] = "Some units failed; see msrEtlSyncUnits for details"
+        else:
+            fields["status"] = AsyncJob.Status.SUCCESS
+        AsyncJob.objects.filter(id=job.id).exclude(status__in=AsyncJob.TERMINAL_STATUSES).update(**fields)
+
+
+def _fail_stale_jobs():
+    stale_hours = int(MsrEtlConfig.job_stale_after_hours)
+    cutoff = timezone.now() - timedelta(hours=stale_hours)
+    AsyncJob.objects.filter(module="msr_etl", created_at__lt=cutoff).exclude(
+        status__in=AsyncJob.TERMINAL_STATUSES
+    ).update(
+        status=AsyncJob.Status.FAILED,
+        error="Job exceeded job_stale_after_hours without completing",
+        finished_at=timezone.now(),
+        updated_at=timezone.now(),
+    )
+
+
+def cleanup_staged_payloads():
+    """FAILED units keep raw_payload until resolved - retrying must not
+    re-pay the UBR fetch."""
+    retention_hours = int(MsrEtlConfig.staging_retention_hours)
+    cutoff = timezone.now() - timedelta(hours=retention_hours)
+    updated = MsrEtlSyncUnit.objects.filter(
+        sync_status=MsrEtlSyncUnit.Status.SYNCED,
+        raw_payload__isnull=False,
+        updated_at__lt=cutoff,
+    ).update(raw_payload=None, updated_at=timezone.now())
+    if updated:
+        logger.info("Purged raw_payload for %s synced sync units past retention", updated)

--- a/msr_etl/tests/test_scheduled_tasks.py
+++ b/msr_etl/tests/test_scheduled_tasks.py
@@ -1,0 +1,201 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from core.models import AsyncJob
+from core.test_helpers import create_test_interactive_user
+from msr_etl.models import MsrEtlSyncUnit
+from msr_etl.scheduled_tasks import (
+    cleanup_staged_payloads,
+    schedule_tasks,
+    sweep_sync_units,
+)
+
+
+class ScheduleTasksTestCase(TestCase):
+
+    def test_registers_sweeper_and_cleanup(self):
+        scheduler = MagicMock()
+        schedule_tasks(scheduler)
+        job_ids = [call.kwargs["id"] for call in scheduler.add_job.call_args_list]
+        self.assertIn("msr_etl_sweep_sync_units", job_ids)
+        self.assertIn("msr_etl_cleanup_staged_payloads", job_ids)
+
+
+class SweepSyncUnitsTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = create_test_interactive_user(username="sweep_tester")
+
+    def _create_job(self, **kwargs):
+        defaults = dict(module="msr_etl", job_type="ubr_individuals_import", task="x.y", user=self.user)
+        defaults.update(kwargs)
+        return AsyncJob.objects.create(**defaults)
+
+    def test_requeues_failed_units_below_max_attempts(self):
+        job = self._create_job()
+        below_cap = MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.FAILED, attempts=1,
+        )
+        at_cap = MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:10-19",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.FAILED, attempts=3,
+        )
+
+        with patch("msr_etl.scheduled_tasks.sync_staged_units"):
+            sweep_sync_units()
+
+        below_cap.refresh_from_db()
+        at_cap.refresh_from_db()
+        self.assertEqual(below_cap.sync_status, MsrEtlSyncUnit.Status.PENDING)
+        self.assertEqual(at_cap.sync_status, MsrEtlSyncUnit.Status.FAILED)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_syncs_orphaned_units_with_a_reconstructed_reporter(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING, total=4, processed=1)
+        MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING,
+        )
+
+        sweep_sync_units()
+
+        mock_sync.assert_called_once()
+        args, kwargs = mock_sync.call_args
+        self.assertEqual(args[0], job.id)
+        self.assertIsNotNone(kwargs["reporter"])
+        self.assertEqual(kwargs["user"], self.user)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_skips_reporter_when_job_total_never_set(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING)
+        MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING,
+        )
+
+        sweep_sync_units()
+
+        mock_sync.assert_called_once_with(job.id, reporter=None, user=self.user)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_closes_job_as_success_once_processed_reaches_total(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING, total=2, processed=2)
+        MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.SYNCED,
+        )
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.SUCCESS)
+        self.assertIsNotNone(job.finished_at)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_closes_job_as_partial_when_a_unit_failed(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING, total=2, processed=2)
+        MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.FAILED,
+        )
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.PARTIAL)
+        self.assertTrue(job.error)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_leaves_job_open_when_processed_below_total(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING, total=4, processed=2)
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.RUNNING)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_ignores_jobs_that_never_set_total(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING)
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.RUNNING)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_fails_stale_jobs_beyond_job_stale_after_hours(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING)
+        AsyncJob.objects.filter(id=job.id).update(created_at=timezone.now() - timedelta(hours=13))
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.FAILED)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_leaves_fresh_jobs_alone(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.RUNNING)
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.RUNNING)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_does_not_touch_already_terminal_jobs(self, mock_sync):
+        job = self._create_job(status=AsyncJob.Status.SUCCESS, total=1, processed=1)
+        AsyncJob.objects.filter(id=job.id).update(created_at=timezone.now() - timedelta(hours=13))
+
+        sweep_sync_units()
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, AsyncJob.Status.SUCCESS)
+        self.assertIsNone(job.error)
+
+
+class CleanupStagedPayloadsTestCase(TestCase):
+
+    def _unit(self, sync_status, updated_hours_ago, payload=None):
+        unit = MsrEtlSyncUnit.objects.create(
+            job_uuid="55555555-5555-5555-5555-555555555555",
+            unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK,
+            unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.STAGED,
+            sync_status=sync_status,
+            raw_payload=payload if payload is not None else [{"id": 1}],
+        )
+        MsrEtlSyncUnit.objects.filter(id=unit.id).update(
+            updated_at=timezone.now() - timedelta(hours=updated_hours_ago)
+        )
+        return unit
+
+    def test_purges_synced_units_past_retention(self):
+        unit = self._unit(MsrEtlSyncUnit.Status.SYNCED, updated_hours_ago=49)
+
+        cleanup_staged_payloads()
+
+        unit.refresh_from_db()
+        self.assertIsNone(unit.raw_payload)
+        self.assertEqual(unit.sync_status, MsrEtlSyncUnit.Status.SYNCED)
+
+    def test_keeps_synced_units_within_retention(self):
+        unit = self._unit(MsrEtlSyncUnit.Status.SYNCED, updated_hours_ago=1)
+
+        cleanup_staged_payloads()
+
+        unit.refresh_from_db()
+        self.assertIsNotNone(unit.raw_payload)
+
+    def test_never_purges_failed_units(self):
+        unit = self._unit(MsrEtlSyncUnit.Status.FAILED, updated_hours_ago=100)
+
+        cleanup_staged_payloads()
+
+        unit.refresh_from_db()
+        self.assertIsNotNone(unit.raw_payload)


### PR DESCRIPTION
## What

Closes #54. Stacked on #59 (which now includes #57/#58) - this diff is the sweeper/cleanup delta only.

New `msr_etl/scheduled_tasks.py`, auto-discovered by core's per-module scheduler discovery loop:

- `sweep_sync_units` (every `sync_sweep_interval_minutes`) - crash recovery only:
  - Requeues `FAILED` sync units below `sync_unit_max_attempts` back to `PENDING`.
  - Retries orphaned staged units via `sync_staged_units`, reconstructing a `ProgressReporter` per job so retried units still advance `processed`/`metrics` - without this, a job finished entirely by the sweeper would never reach `processed >= total` and would stay open forever.
  - Closes jobs whose `processed >= total` (a targeted status `update()` only, never touching counters) as `SUCCESS` or `PARTIAL` depending on whether any unit failed. `>=` rather than `==` because a unit that fails then succeeds on retry advances twice.
  - Fails jobs stale beyond `job_stale_after_hours`.
- `cleanup_staged_payloads` (hourly) - purges `raw_payload` for `SYNCED` units past `staging_retention_hours`. `FAILED` units keep theirs until resolved, so a retry never re-pays the UBR fetch.

## Verification

- New tests: `test_scheduled_tasks.py` - registration, requeue-below-cap, orphaned-unit sync with reporter reconstruction, close-on-processed-reaches-total (success/partial), leaves-open-when-short, ignores-total-never-set, stale-job failure, terminal-jobs untouched, retention purge (synced/kept/never-fails).
- Full `msr_etl` suite: 97 tests, same 4 failures / 11 errors as the existing baseline (unrelated files) - no regressions.
- `makemigrations --check` clean; module imports without error.
