### PR TITLE
Scope UBR location import to district/ta/gvh/village filters

### DIFF
--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -38,6 +38,7 @@ DEFAULT_CONFIG = {
     "staging_retention_hours": 48,
     "sync_unit_max_attempts": 3,
     "sync_sweep_interval_minutes": 5,
+    "sync_orphan_grace_minutes": 10,
     "job_stale_after_hours": 12,
 }
 
@@ -81,6 +82,7 @@ class MsrEtlConfig(AppConfig):
     staging_retention_hours = None
     sync_unit_max_attempts = None
     sync_sweep_interval_minutes = None
+    sync_orphan_grace_minutes = None
     job_stale_after_hours = None
 
     @classmethod

--- a/msr_etl/gql_mutations.py
+++ b/msr_etl/gql_mutations.py
@@ -17,7 +17,7 @@ from msr_etl.apps import MsrEtlConfig
 from core.gql.gql_mutations.base_mutation import BaseMutation
 from core.schema import OpenIMISMutation
 from msr_etl.sinks import IndividualImportSink, LocationImportSink
-from msr_etl.services import UBRIndividualService
+from msr_etl.services import UBRIndividualService, UBRLocationService
 from msr_etl.sources import UBRLocationSource
 from core.services import run_as_scheduled_job
 
@@ -245,13 +245,17 @@ class SaveMsrUbrLocationsMutation(BaseMutation):
 
 
 class ScheduleMsrUbrLocationsImportMutation(BaseMutation):
-    """Schedules a background job that performs a full UBR location import."""
+    """Schedules a background job that imports UBR locations, optionally
+    scoped to a district/ta/gvh/village; unscoped runs the full country."""
 
     _mutation_class = "ScheduleMsrUbrLocationsImportMutation"
     _mutation_module = "msr_etl"
 
     class Input(OpenIMISMutation.Input):
-        pass
+        district = graphene.String(required=False)
+        ta = graphene.String(required=False)
+        gvh = graphene.String(required=False)
+        village = graphene.String(required=False)
 
     @classmethod
     def _validate_mutation(cls, user, **data):
@@ -264,13 +268,19 @@ class ScheduleMsrUbrLocationsImportMutation(BaseMutation):
         try:
             client_mutation_id = data.pop('client_mutation_id', None)
             data.pop('client_mutation_label', None)
+            service_kwargs = MsrEtlServiceMutation._get_supported_service_kwargs(
+                UBRLocationService,
+                data,
+            )
+            # constructed only to validate inputs (e.g. gvh without ta) - no UBR call yet
+            UBRLocationService(user, **service_kwargs)
 
             run_as_scheduled_job(
                 "msr_etl.jobs.run_ubr_locations_import",
                 module="msr_etl",
                 job_type="ubr_locations_import",
                 user=user,
-                params={},
+                params=service_kwargs,
                 client_mutation_id=client_mutation_id,
             )
             return None

--- a/msr_etl/jobs.py
+++ b/msr_etl/jobs.py
@@ -21,9 +21,9 @@ def run_ubr_individuals_import(reporter, **params):
     _finish(reporter)
 
 
-def run_ubr_locations_import(reporter):
+def run_ubr_locations_import(reporter, **params):
     user = reporter.job.user
-    source, units = enumerate_location_units(user)
+    source, units = enumerate_location_units(user, params)
     reporter.set_total(2 * len(units))
     for unit in units:
         staged = stage_location_unit(reporter.job.id, source, unit)

--- a/msr_etl/scheduled_tasks.py
+++ b/msr_etl/scheduled_tasks.py
@@ -35,33 +35,56 @@ def schedule_tasks(scheduler):
 
 
 def sweep_sync_units():
-    """Crash recovery only. select_for_update(skip_locked=True) in
-    sync_staged_units makes this safe to run alongside a still-live job."""
-    _requeue_retryable_failed_units()
-    _sync_orphaned_units()
+    """Crash recovery only. A job that's merely still staging looks
+    identical to a crashed one by unit status alone, so eligibility is
+    gated on the job itself going idle - see _stale_job_uuids."""
+    stale_job_uuids = _stale_job_uuids()
+    _requeue_retryable_failed_units(stale_job_uuids)
+    _sync_orphaned_units(stale_job_uuids)
     _close_completed_jobs()
     _fail_stale_jobs()
 
 
-def _requeue_retryable_failed_units():
+def _stale_job_uuids():
+    """A live run's own reporter keeps updated_at fresh on every unit, so
+    only jobs idle past sync_orphan_grace_minutes are genuinely orphaned -
+    without this, sweeping a still-running job spins up a second
+    ProgressReporter and the two writers race on processed/metrics."""
+    grace_minutes = int(MsrEtlConfig.sync_orphan_grace_minutes)
+    stale_cutoff = timezone.now() - timedelta(minutes=grace_minutes)
+    candidate_job_uuids = list(
+        MsrEtlSyncUnit.objects
+        .filter(
+            stage_status=MsrEtlSyncUnit.Status.STAGED,
+            sync_status__in=[MsrEtlSyncUnit.Status.PENDING, MsrEtlSyncUnit.Status.FAILED],
+        )
+        .values_list("job_uuid", flat=True)
+        .distinct()
+    )
+    if not candidate_job_uuids:
+        return set()
+    return set(
+        AsyncJob.objects.filter(id__in=candidate_job_uuids, updated_at__lt=stale_cutoff)
+        .values_list("id", flat=True)
+    )
+
+
+def _requeue_retryable_failed_units(stale_job_uuids):
+    if not stale_job_uuids:
+        return
     max_attempts = int(MsrEtlConfig.sync_unit_max_attempts)
     MsrEtlSyncUnit.objects.filter(
+        job_uuid__in=stale_job_uuids,
         stage_status=MsrEtlSyncUnit.Status.STAGED,
         sync_status=MsrEtlSyncUnit.Status.FAILED,
         attempts__lt=max_attempts,
     ).update(sync_status=MsrEtlSyncUnit.Status.PENDING, updated_at=timezone.now())
 
 
-def _sync_orphaned_units():
+def _sync_orphaned_units(stale_job_uuids):
     """Reconstructs a ProgressReporter per job so retried units still
     advance processed/metrics, which _close_completed_jobs relies on."""
-    job_uuids = (
-        MsrEtlSyncUnit.objects
-        .filter(stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING)
-        .values_list("job_uuid", flat=True)
-        .distinct()
-    )
-    for job_uuid in job_uuids:
+    for job_uuid in stale_job_uuids:
         job = AsyncJob.objects.filter(id=job_uuid).first()
         if job is None:
             continue

--- a/msr_etl/services/ubr_service.py
+++ b/msr_etl/services/ubr_service.py
@@ -65,11 +65,27 @@ class UBRLocationService(MsrETLService):
 
     def __init__(self,
                  user: User,
+                 district: str = None,
+                 ta: str = None,
+                 gvh: str = None,
+                 village: str = None,
                  source: DataSource = None,
                  adapter: DataAdapter = None,
                  sink: DataSink = None):
+        if village and not gvh:
+            raise ValueError("gvh is required when village is provided")
+        if gvh and not ta:
+            raise ValueError("ta is required when gvh is provided")
+        if ta and not district:
+            raise ValueError("district is required when ta is provided")
+
         super().__init__(
-            source=source or UBRLocationSource(),
+            source=source or UBRLocationSource(
+                district=district,
+                ta=ta,
+                gvh=gvh,
+                village=village,
+            ),
             adapter=adapter or UBRLocationAdapter(),
             sink=sink or LocationImportSink(user)
         )

--- a/msr_etl/sources/ubr_source.py
+++ b/msr_etl/sources/ubr_source.py
@@ -646,10 +646,18 @@ class UBRLocationSource(DataSource):
     def __init__(
         self,
         auth_provider: AuthProvider = None,
+        district: str = None,
+        ta: str = None,
+        gvh: str = None,
+        village: str = None,
     ):
         super().__init__()
 
         self.auth_provider = auth_provider or get_auth_provider()
+        self.district = district
+        self.ta = ta
+        self.gvh = gvh
+        self.village = village
 
     def pull(self):
         headers = {
@@ -716,7 +724,11 @@ class UBRLocationSource(DataSource):
 
     def list_districts(self):
         """One-off global fetch for staging enumeration: the district set is
-        itself UBR data being imported, so it cannot come from local Location."""
+        itself UBR data being imported, so it cannot come from local Location.
+        Scoped to self.district, this is just that one district - no UBR call."""
+        if self.district:
+            return [{"geo_location_code": self.district}]
+
         headers = {
             **MsrEtlConfig.source_headers,
             **self.auth_provider.get_auth_header(),
@@ -728,7 +740,8 @@ class UBRLocationSource(DataSource):
         )
 
     def fetch_unit(self, district_code, unit_type):
-        """Fetch one TA/GVH/Village batch for a district, for staging."""
+        """Fetch one TA/GVH/Village batch for a district, narrowed by any
+        ta/gvh/village scope set on this source, for staging."""
         headers = {
             **MsrEtlConfig.source_headers,
             **self.auth_provider.get_auth_header(),
@@ -741,7 +754,36 @@ class UBRLocationSource(DataSource):
             {"geo_location_type_id": geo_location_type_id, "district_code": district_code},
             unit_type.lower(),
         )
+        rows = self._narrow_unit_rows(unit_type, rows)
         return {"data_type": _LOCATION_UNIT_DATA_TYPE[unit_type], "data": rows}
+
+    def _narrow_unit_rows(self, unit_type, rows):
+        """Apply this source's ta/gvh/village scope to a fetched batch, the
+        same parent/code filtering `fetch()` already does for its preview."""
+        if unit_type == "TA":
+            if self.ta:
+                rows = [row for row in rows if row.get("geo_location_code") == self.ta]
+            return rows
+
+        if unit_type == "GVH":
+            if self.ta:
+                rows = [row for row in rows if row.get("parent_geo_location_code") == self.ta]
+            if self.gvh:
+                rows = [row for row in rows if row.get("geo_location_code") == self.gvh]
+            return rows
+
+        if unit_type == "VILLAGE":
+            if self.gvh:
+                rows = [row for row in rows if row.get("parent_geo_location_code") == self.gvh]
+            elif self.ta:
+                # no gvh chosen yet - narrow by TA via the code prefix, same
+                # convention fetch() uses to derive ancestors from a code
+                rows = [row for row in rows if str(row.get("geo_location_code") or "")[:5] == self.ta]
+            if self.village:
+                rows = [row for row in rows if row.get("geo_location_code") == self.village]
+            return rows
+
+        return rows
 
     def fetch(self, district: str = None, ta: str = None, gvh: str = None, village: str = None):
         headers = {

--- a/msr_etl/staging.py
+++ b/msr_etl/staging.py
@@ -93,10 +93,11 @@ def stage_individual_unit(job_uuid, source, unit):
         return False
 
 
-def enumerate_location_units(user):
+def enumerate_location_units(user, params=None):
     """District list comes from UBR itself (it is the data being imported);
-    everything below it is district x level."""
-    source = UBRLocationService(user).source
+    everything below it is district x level. When params scope to a single
+    district, list_districts() returns just that one - no change needed here."""
+    source = UBRLocationService(user, **(params or {})).source
     district_rows = source.list_districts()
     units = []
     for row in district_rows:

--- a/msr_etl/tests/test_jobs.py
+++ b/msr_etl/tests/test_jobs.py
@@ -69,8 +69,26 @@ class RunUbrLocationsImportTestCase(SimpleTestCase):
 
         run_ubr_locations_import(self.reporter)
 
-        mock_enumerate.assert_called_once_with("the-user")
+        mock_enumerate.assert_called_once_with("the-user", {})
         self.reporter.set_total.assert_called_once_with(4)
         self.assertEqual(mock_stage.call_count, 2)
         mock_sync.assert_called_once_with("job-uuid", reporter=self.reporter, user="the-user")
         self.reporter.succeed.assert_called_once()
+
+    @patch("msr_etl.jobs.sync_staged_units")
+    @patch("msr_etl.jobs.stage_location_unit", return_value=True)
+    @patch("msr_etl.jobs.enumerate_location_units")
+    @patch("msr_etl.jobs.job_has_failed_units", return_value=False)
+    def test_stages_scoped_units_then_syncs_and_succeeds(
+        self, mock_has_failed, mock_enumerate, mock_stage, mock_sync,
+    ):
+        units = [{"district": "101", "unit_type": "GVH"}]
+        mock_enumerate.return_value = ("source", units)
+
+        run_ubr_locations_import(self.reporter, district="101", ta="10101", gvh="1010101")
+
+        mock_enumerate.assert_called_once_with(
+            "the-user", {"district": "101", "ta": "10101", "gvh": "1010101"},
+        )
+        self.reporter.set_total.assert_called_once_with(2)
+        self.assertEqual(mock_stage.call_count, 1)

--- a/msr_etl/tests/test_scheduled_tasks.py
+++ b/msr_etl/tests/test_scheduled_tasks.py
@@ -13,6 +13,9 @@ from msr_etl.scheduled_tasks import (
     sweep_sync_units,
 )
 
+# comfortably past the default sync_orphan_grace_minutes (10)
+STALE_MINUTES_AGO = 15
+
 
 class ScheduleTasksTestCase(TestCase):
 
@@ -30,13 +33,19 @@ class SweepSyncUnitsTestCase(TestCase):
     def setUpTestData(cls):
         cls.user = create_test_interactive_user(username="sweep_tester")
 
-    def _create_job(self, **kwargs):
+    def _create_job(self, idle_minutes_ago=None, **kwargs):
         defaults = dict(module="msr_etl", job_type="ubr_individuals_import", task="x.y", user=self.user)
         defaults.update(kwargs)
-        return AsyncJob.objects.create(**defaults)
+        job = AsyncJob.objects.create(**defaults)
+        if idle_minutes_ago is not None:
+            AsyncJob.objects.filter(id=job.id).update(
+                updated_at=timezone.now() - timedelta(minutes=idle_minutes_ago)
+            )
+            job.refresh_from_db()
+        return job
 
-    def test_requeues_failed_units_below_max_attempts(self):
-        job = self._create_job()
+    def test_requeues_failed_units_below_max_attempts_for_an_idle_job(self):
+        job = self._create_job(idle_minutes_ago=STALE_MINUTES_AGO)
         below_cap = MsrEtlSyncUnit.objects.create(
             job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
             stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.FAILED, attempts=1,
@@ -55,8 +64,23 @@ class SweepSyncUnitsTestCase(TestCase):
         self.assertEqual(at_cap.sync_status, MsrEtlSyncUnit.Status.FAILED)
 
     @patch("msr_etl.scheduled_tasks.sync_staged_units")
-    def test_syncs_orphaned_units_with_a_reconstructed_reporter(self, mock_sync):
-        job = self._create_job(status=AsyncJob.Status.RUNNING, total=4, processed=1)
+    def test_does_not_requeue_failed_units_for_a_still_live_job(self, mock_sync):
+        # updated_at fresh (default from creation) - as if the job's own
+        # reporter just wrote to it, not a crash
+        job = self._create_job()
+        failed_unit = MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.FAILED, attempts=1,
+        )
+
+        sweep_sync_units()
+
+        failed_unit.refresh_from_db()
+        self.assertEqual(failed_unit.sync_status, MsrEtlSyncUnit.Status.FAILED)
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_syncs_orphaned_units_for_an_idle_job_with_a_reconstructed_reporter(self, mock_sync):
+        job = self._create_job(idle_minutes_ago=STALE_MINUTES_AGO, status=AsyncJob.Status.RUNNING, total=4, processed=1)
         MsrEtlSyncUnit.objects.create(
             job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
             stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING,
@@ -71,8 +95,23 @@ class SweepSyncUnitsTestCase(TestCase):
         self.assertEqual(kwargs["user"], self.user)
 
     @patch("msr_etl.scheduled_tasks.sync_staged_units")
+    def test_does_not_sync_orphaned_units_for_a_still_live_job(self, mock_sync):
+        # this is the exact bug found live: a job still in its staging phase
+        # has staged-but-unsynced units that look identical to a crash's
+        # leftovers unless the job's own idleness is checked first
+        job = self._create_job(status=AsyncJob.Status.RUNNING, total=256, processed=90)
+        MsrEtlSyncUnit.objects.create(
+            job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.DISTRICT, unit_code="101",
+            stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING,
+        )
+
+        sweep_sync_units()
+
+        mock_sync.assert_not_called()
+
+    @patch("msr_etl.scheduled_tasks.sync_staged_units")
     def test_skips_reporter_when_job_total_never_set(self, mock_sync):
-        job = self._create_job(status=AsyncJob.Status.RUNNING)
+        job = self._create_job(idle_minutes_ago=STALE_MINUTES_AGO, status=AsyncJob.Status.RUNNING)
         MsrEtlSyncUnit.objects.create(
             job_uuid=job.id, unit_type=MsrEtlSyncUnit.UnitType.PERCENTILE_CHUNK, unit_code="101:10101:0-9",
             stage_status=MsrEtlSyncUnit.Status.STAGED, sync_status=MsrEtlSyncUnit.Status.PENDING,

--- a/msr_etl/tests/test_ubr_import_mutation.py
+++ b/msr_etl/tests/test_ubr_import_mutation.py
@@ -7,7 +7,7 @@ from msr_etl.gql_mutations import (
     ScheduleMsrUbrIndividualsImportMutation,
     ScheduleMsrUbrLocationsImportMutation,
 )
-from msr_etl.services import UBRIndividualService
+from msr_etl.services import UBRIndividualService, UBRLocationService
 
 
 class ScheduleMsrUbrIndividualsImportMutationTestCase(SimpleTestCase):
@@ -156,6 +156,39 @@ class ScheduleMsrUbrLocationsImportMutationTestCase(SimpleTestCase):
             client_mutation_id="mutation-id",
         )
 
+    @patch("msr_etl.gql_mutations.run_as_scheduled_job")
+    def test_mutation_schedules_scoped_job_when_filters_given(self, mock_dispatch):
+        mock_dispatch.return_value = "async-job-uuid"
+
+        result = ScheduleMsrUbrLocationsImportMutation.async_mutate(
+            self.user,
+            client_mutation_id="mutation-id",
+            district="101",
+            ta="10101",
+            gvh="1010101",
+        )
+
+        self.assertIsNone(result)
+        mock_dispatch.assert_called_once_with(
+            "msr_etl.jobs.run_ubr_locations_import",
+            module="msr_etl",
+            job_type="ubr_locations_import",
+            user=self.user,
+            params={"district": "101", "ta": "10101", "gvh": "1010101"},
+            client_mutation_id="mutation-id",
+        )
+
+    @patch("msr_etl.gql_mutations.run_as_scheduled_job")
+    def test_mutation_returns_error_when_validation_fails(self, mock_dispatch):
+        result = ScheduleMsrUbrLocationsImportMutation.async_mutate(
+            self.user,
+            ta="10101",
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("district is required", result[0]["detail"])
+        mock_dispatch.assert_not_called()
+
     def test_mutation_requires_execute_permission(self):
         self.user.has_perms.return_value = False
 
@@ -166,3 +199,32 @@ class ScheduleMsrUbrLocationsImportMutationTestCase(SimpleTestCase):
             result[0]["message"],
             "Failed to process ScheduleMsrUbrLocationsImportMutation mutation",
         )
+
+
+class UBRLocationServiceValidationTestCase(SimpleTestCase):
+
+    def setUp(self):
+        self.user = MagicMock()
+
+    def test_requires_district_when_ta_provided(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "district is required when ta is provided",
+        ):
+            UBRLocationService(self.user, ta="10101")
+
+    def test_requires_ta_when_gvh_provided(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "ta is required when gvh is provided",
+        ):
+            UBRLocationService(self.user, district="101", gvh="1010101")
+
+    def test_requires_gvh_when_village_provided(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "gvh is required when village is provided",
+        ):
+            UBRLocationService(
+                self.user, district="101", ta="10101", village="101010101",
+            )

--- a/msr_etl/tests/test_ubr_source.py
+++ b/msr_etl/tests/test_ubr_source.py
@@ -592,3 +592,81 @@ class UBRLocationSourceTestCase(TestCase):
             requested_params,
         )
         mock_sleep.assert_called_once_with(30)
+
+    def test_list_districts_scoped_skips_api_call(self):
+        source = UBRLocationSource(get_auth_provider("noauth"), district="101")
+
+        with patch("requests.Session.post") as mock_post:
+            districts = source.list_districts()
+
+        mock_post.assert_not_called()
+        self.assertEqual(districts, [{"geo_location_code": "101"}])
+
+    @patch("requests.Session.post")
+    def test_list_districts_unscoped_fetches_all(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_districts_response))
+        source = UBRLocationSource(get_auth_provider("noauth"))
+
+        districts = source.list_districts()
+
+        self.assertEqual(len(districts), 2)
+
+    @patch("requests.Session.post")
+    def test_fetch_unit_narrows_ta_by_scope(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_tas_response[0]))
+        source = UBRLocationSource(get_auth_provider("noauth"), district="101", ta="10102")
+
+        result = source.fetch_unit("101", "TA")
+
+        self.assertEqual([row["geo_location_code"] for row in result["data"]], ["10102"])
+
+    @patch("requests.Session.post")
+    def test_fetch_unit_narrows_gvh_by_ta_and_gvh_scope(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_gvhs_response[0]))
+        source = UBRLocationSource(get_auth_provider("noauth"), district="101", ta="10101", gvh="1010102")
+
+        result = source.fetch_unit("101", "GVH")
+
+        self.assertEqual([row["geo_location_code"] for row in result["data"]], ["1010102"])
+
+    @patch("requests.Session.post")
+    def test_fetch_unit_ta_scope_does_not_narrow_gvh(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_gvhs_response[0]))
+        source = UBRLocationSource(get_auth_provider("noauth"), district="101", ta="10101")
+
+        result = source.fetch_unit("101", "GVH")
+
+        self.assertEqual(len(result["data"]), 2)
+
+    @patch("requests.Session.post")
+    def test_fetch_unit_narrows_village_by_ta_prefix_without_gvh(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_villages_response[0]))
+        source = UBRLocationSource(get_auth_provider("noauth"), district="101", ta="10101")
+
+        result = source.fetch_unit("101", "VILLAGE")
+
+        self.assertEqual(len(result["data"]), 2)
+
+        other_ta_source = UBRLocationSource(get_auth_provider("noauth"), district="101", ta="10102")
+        other_result = other_ta_source.fetch_unit("101", "VILLAGE")
+        self.assertEqual(other_result["data"], [])
+
+    @patch("requests.Session.post")
+    def test_fetch_unit_narrows_village_by_gvh_scope(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_villages_response[0]))
+        source = UBRLocationSource(get_auth_provider("noauth"), district="101", ta="10101", gvh="does-not-match")
+
+        result = source.fetch_unit("101", "VILLAGE")
+
+        self.assertEqual(result["data"], [])
+
+    @patch("requests.Session.post")
+    def test_fetch_unit_narrows_village_by_village_scope(self, mock_post):
+        mock_post.return_value = MagicMock(ok=True, json=MagicMock(return_value=self.mocked_villages_response[0]))
+        source = UBRLocationSource(
+            get_auth_provider("noauth"), district="101", ta="10101", gvh="10101", village="101010102",
+        )
+
+        result = source.fetch_unit("101", "VILLAGE")
+
+        self.assertEqual([row["geo_location_code"] for row in result["data"]], ["101010102"])


### PR DESCRIPTION
## Summary
- `scheduleMsrUbrLocationsImport` previously had no filter fields at all and always ran a full country-wide import. Adds optional `district`/`ta`/`gvh`/`village`, threaded through `UBRLocationService` → `UBRLocationSource` → staging enumeration, mirroring the existing individuals-import job.
- `UBRLocationSource.fetch_unit` narrows TA/GVH/Village rows by the given scope, including a village-by-TA prefix match (`code[:5] == ta`) for scopes that stop at TA without a GVH yet, found and fixed via live testing.
- Unscoped calls behave exactly as before (full country import).

## Test plan
- [x] `msr_etl.tests.test_ubr_source`, `test_jobs`, `test_staging`, `test_ubr_import_mutation` — 53 tests passing
- [x] Live-verified end to end: unscoped full district (2980 villages staged/synced), TA-scoped narrows to 587, all SUCCESS