### PR TITLE
feat: include marital status and disability to household members

### DIFF
--- a/msr_etl/adapters/ubr_adapter.py
+++ b/msr_etl/adapters/ubr_adapter.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Iterable
 
 from msr_etl.adapters.base import DataAdapter
+from msr_etl.apps import MsrEtlConfig
 from location.models import Location
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,8 @@ class UBRIndividualAdapter(DataAdapter):
                     "national_id": member.get("national_id"),
                     "fit_for_work": member.get("fit_for_work"),
                     "gender": self.parse_gender(member),
+                    "marital_status": self.parse_marital_status(member),
+                    "disability": self.parse_disability(member),
                     "household_mobile_number": mobile_number,
                     "household_pmt_score": pmt_score,
                     "household_wealth_quintile": wealth_quintile,
@@ -99,6 +102,28 @@ class UBRIndividualAdapter(DataAdapter):
     @staticmethod
     def parse_gender(member_dict):
         return member_dict.get("gender", {}).get("parameter_name")
+
+    @staticmethod
+    def parse_marital_status(member_dict):
+        return member_dict.get("marital_status", {}).get("parameter_name")
+
+    @staticmethod
+    def parse_disability(member_dict):
+        """Disability status for a member.
+
+        UBR doesn't expose disability as its own field. It's one entry among several generic
+        ``household_member_combined_responses``, each carrying a ``general_parameter`` whose ``parameter_id`` 
+        identifies which question it answers. The disability question's ``parameter_id`` is configurable via 
+        ``MsrEtlConfig.ubr_disability_parameter_id`` (default ``6``).
+        """
+        disability_parameter_id = str(
+            getattr(MsrEtlConfig, "ubr_disability_parameter_id", 6)
+        )
+        for response in member_dict.get("household_member_combined_responses") or []:
+            general_parameter = response.get("general_parameter") or {}
+            if str(general_parameter.get("parameter_id")) == disability_parameter_id:
+                return general_parameter.get("parameter_name")
+        return None
 
     @staticmethod
     def parse_individual_role(member_dict):

--- a/msr_etl/apps.py
+++ b/msr_etl/apps.py
@@ -21,6 +21,7 @@ DEFAULT_CONFIG = {
     "source_ca_bundle_path": "",
 
     "ubr_programme_parameter_id": 2,
+    "ubr_disability_parameter_id": 6,
 
     "adapter_first_name_field": "firstName",
     "adapter_last_name_field": "lastName",
@@ -65,6 +66,7 @@ class MsrEtlConfig(AppConfig):
     source_ca_bundle_path = None
 
     ubr_programme_parameter_id = None
+    ubr_disability_parameter_id = None
 
     adapter_first_name_field = None
     adapter_last_name_field = None

--- a/msr_etl/tests/test_ubr_adapter.py
+++ b/msr_etl/tests/test_ubr_adapter.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 from msr_etl.adapters.ubr_adapter import UBRIndividualAdapter, UBRLocationAdapter
+from msr_etl.apps import MsrEtlConfig
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +44,23 @@ class UBRIndividualAdapterTestCase(TestCase):
                         "date_of_birth": "1980-03-03",
                         "relationship": {"parameter_name": "Head"},
                         "gender": {"parameter_name": "Female"},
+                        "marital_status": {"parameter_name": "Divorced"},
                         "national_id": "123456",
                         "fit_for_work": 1,
+                        "household_member_combined_responses": [
+                            {
+                                "general_parameter": {
+                                    "parameter_id": 6,
+                                    "parameter_name": "Not disabled",
+                                },
+                            },
+                            {
+                                "general_parameter": {
+                                    "parameter_id": 7,
+                                    "parameter_name": "None",
+                                },
+                            },
+                        ],
                     },
                     {
                         "id": 1235,
@@ -95,6 +111,8 @@ class UBRIndividualAdapterTestCase(TestCase):
         self.assertEqual(head["national_id"], "123456")
         self.assertEqual(head["fit_for_work"], 1)
         self.assertEqual(head["gender"], 'Female')
+        self.assertEqual(head["marital_status"], "Divorced")
+        self.assertEqual(head["disability"], "Not disabled")
         self.assertEqual(head["household_mobile_number"], '0987654321')
         self.assertEqual(head["household_pmt_score"], 2.5)
         self.assertEqual(head["household_wealth_quintile"], "Poorest")
@@ -102,6 +120,11 @@ class UBRIndividualAdapterTestCase(TestCase):
         self.assertEqual(head["group_village_head_code"], "2090510")
         self.assertEqual(head["traditional_authority_name"], "Test TA")
         self.assertEqual(head["traditional_authority_code"], "20905")
+
+        # Members without marital_status/combined-responses in the source payload
+        # should resolve to None rather than raising.
+        self.assertIsNone(transformed_data[1]["marital_status"])
+        self.assertIsNone(transformed_data[1]["disability"])
 
         self.assertEqual(transformed_data[1]["individual_role"], "SPOUSE")
         self.assertEqual(transformed_data[2]["individual_role"], "DAUGHTER")
@@ -119,6 +142,36 @@ class UBRIndividualAdapterTestCase(TestCase):
             self.adapter.transform(None)
 
         self.assertEqual(str(cm.exception), "Invalid input, expect input not to be None")
+
+    def test_parse_marital_status_returns_parameter_name(self):
+        member = {"marital_status": {"parameter_name": "Never married"}}
+        self.assertEqual(self.adapter.parse_marital_status(member), "Never married")
+
+    def test_parse_marital_status_missing_returns_none(self):
+        self.assertIsNone(self.adapter.parse_marital_status({}))
+
+    def test_parse_disability_matches_configured_parameter_id(self):
+        member = {
+            "household_member_combined_responses": [
+                {"general_parameter": {"parameter_id": 7, "parameter_name": "None"}},
+                {"general_parameter": {"parameter_id": 6, "parameter_name": "Mentally disabled"}},
+            ],
+        }
+        self.assertEqual(self.adapter.parse_disability(member), "Mentally disabled")
+
+    def test_parse_disability_missing_responses_returns_none(self):
+        self.assertIsNone(self.adapter.parse_disability({}))
+        self.assertIsNone(self.adapter.parse_disability({"household_member_combined_responses": []}))
+
+    def test_parse_disability_uses_configured_parameter_id(self):
+        member = {
+            "household_member_combined_responses": [
+                {"general_parameter": {"parameter_id": 6, "parameter_name": "Not disabled"}},
+                {"general_parameter": {"parameter_id": 99, "parameter_name": "Physically disabled"}},
+            ],
+        }
+        with patch.object(MsrEtlConfig, "ubr_disability_parameter_id", 99):
+            self.assertEqual(self.adapter.parse_disability(member), "Physically disabled")
 
     def test_parse_individual_role_valid_cases(self):
         member_son = {"relationship": {"parameter_name": "Own child"}, "gender": {"parameter_name": "Male"}}


### PR DESCRIPTION
# Description

This PR enhances the household member data model by adding support for **marital status** and **disability information**.

The changes extend the data ingestion and processing workflow to capture and manage these additional attributes, enabling more comprehensive beneficiary profiling, reporting, and analysis. Configuration and parsing logic have been updated to support the new fields throughout the data import process.

# Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Chore (Refactor, Docs, CI/CD)
* [ ] Other, please specify

## Related Issue(s) / Task(s)

* [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
* [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
* [ ] External reference (e.g., Jira):

## Demo

N/A

## Checklist

* [x] Unit tests added/modified
* [ ] I18n translations added/modified